### PR TITLE
Add core runtime and widget scaffolding for CodexTUI

### DIFF
--- a/Sources/CodexTUI/CodexTUI.swift
+++ b/Sources/CodexTUI/CodexTUI.swift
@@ -1,2 +1,13 @@
 import Foundation
+import TerminalInput
+import TerminalOutput
 
+public enum CodexTUI {
+  public static func makeDriver ( scene: Scene, configuration: RuntimeConfiguration = RuntimeConfiguration() ) -> TerminalDriver {
+    let connection = TerminalOutput.FileHandleTerminalConnection()
+    let terminal   = TerminalOutput.Terminal(connection: connection)
+    let input      = TerminalInput()
+
+    return TerminalDriver(scene: scene, terminal: terminal, input: input, configuration: configuration)
+  }
+}

--- a/Sources/CodexTUI/Components/Box.swift
+++ b/Sources/CodexTUI/Components/Box.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+public struct Box : Widget {
+  public var bounds : BoxBounds
+  public var style  : ColorPair
+
+  public init ( bounds: BoxBounds, style: ColorPair = ColorPair() ) {
+    self.bounds  = bounds
+    self.style   = style
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    var commands = [RenderCommand]()
+
+    for column in bounds.column...(bounds.column + bounds.width - 1) {
+      commands.append(
+        RenderCommand(
+          row   : bounds.row,
+          column: column,
+          tile  : SurfaceTile(
+            character : horizontalLine(for: column),
+            attributes: style
+          )
+        )
+      )
+      commands.append(
+        RenderCommand(
+          row   : bounds.maxRow,
+          column: column,
+          tile  : SurfaceTile(
+            character : horizontalLine(for: column),
+            attributes: style
+          )
+        )
+      )
+    }
+
+    for row in bounds.row...(bounds.row + bounds.height - 1) {
+      commands.append(
+        RenderCommand(
+          row   : row,
+          column: bounds.column,
+          tile  : SurfaceTile(
+            character : verticalLine(for: row),
+            attributes: style
+          )
+        )
+      )
+      commands.append(
+        RenderCommand(
+          row   : row,
+          column: bounds.maxCol,
+          tile  : SurfaceTile(
+            character : verticalLine(for: row),
+            attributes: style
+          )
+        )
+      )
+    }
+
+    commands.append(
+      RenderCommand(
+        row   : bounds.row,
+        column: bounds.column,
+        tile  : SurfaceTile(
+          character : "┌",
+          attributes: style
+        )
+      )
+    )
+    commands.append(
+      RenderCommand(
+        row   : bounds.row,
+        column: bounds.maxCol,
+        tile  : SurfaceTile(
+          character : "┐",
+          attributes: style
+        )
+      )
+    )
+    commands.append(
+      RenderCommand(
+        row   : bounds.maxRow,
+        column: bounds.column,
+        tile  : SurfaceTile(
+          character : "└",
+          attributes: style
+        )
+      )
+    )
+    commands.append(
+      RenderCommand(
+        row   : bounds.maxRow,
+        column: bounds.maxCol,
+        tile  : SurfaceTile(
+          character : "┘",
+          attributes: style
+        )
+      )
+    )
+
+    return WidgetLayoutResult(bounds: bounds, commands: commands)
+  }
+
+  private func horizontalLine ( for column: Int ) -> Character {
+    if column == bounds.column || column == bounds.maxCol { return "┼" }
+    return "─"
+  }
+
+  private func verticalLine ( for row: Int ) -> Character {
+    if row == bounds.row || row == bounds.maxRow { return "┼" }
+    return "│"
+  }
+}

--- a/Sources/CodexTUI/Components/MenuBar.swift
+++ b/Sources/CodexTUI/Components/MenuBar.swift
@@ -1,0 +1,83 @@
+import Foundation
+import TerminalInput
+
+public enum MenuItemAlignment {
+  case leading
+  case trailing
+}
+
+public struct MenuItem : Equatable {
+  public var title          : String
+  public var activationKey  : TerminalInput.ControlKey
+  public var alignment      : MenuItemAlignment
+  public var isHighlighted  : Bool
+
+  public init ( title: String, activationKey: TerminalInput.ControlKey, alignment: MenuItemAlignment = .leading, isHighlighted: Bool = false ) {
+    self.title         = title
+    self.activationKey = activationKey
+    self.alignment     = alignment
+    self.isHighlighted = isHighlighted
+  }
+}
+
+public struct MenuBar : Widget {
+  public var items            : [MenuItem]
+  public var style            : ColorPair
+  public var highlightStyle   : ColorPair
+  public var dimHighlightStyle: ColorPair
+
+  public init ( items: [MenuItem], style: ColorPair, highlightStyle: ColorPair, dimHighlightStyle: ColorPair ) {
+    self.items             = items
+    self.style             = style
+    self.highlightStyle    = highlightStyle
+    self.dimHighlightStyle = dimHighlightStyle
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    let row = context.bounds.row
+    var commands = [RenderCommand]()
+
+    var leftColumn  = context.bounds.column
+    var rightColumn = context.bounds.maxCol
+
+    for item in items where item.alignment == .leading {
+      commands.append(contentsOf: render(item: item, row: row, column: leftColumn))
+      leftColumn += item.title.count + 2
+    }
+
+    for item in items.reversed() where item.alignment == .trailing {
+      rightColumn -= item.title.count
+      commands.append(contentsOf: render(item: item, row: row, column: rightColumn))
+      rightColumn -= 2
+    }
+
+    return WidgetLayoutResult(bounds: BoxBounds(row: row, column: context.bounds.column, width: context.bounds.width, height: 1), commands: commands)
+  }
+
+  private func render ( item: MenuItem, row: Int, column: Int ) -> [RenderCommand] {
+    var commands = [RenderCommand]()
+    let characters = Array(item.title)
+
+    for (index, character) in characters.enumerated() {
+      let isFirst    = index == 0
+      let attributes = isFirst ? highlightAttributes(for: item) : style
+
+      commands.append(
+        RenderCommand(
+          row   : row,
+          column: column + index,
+          tile  : SurfaceTile(
+            character : character,
+            attributes: attributes
+          )
+        )
+      )
+    }
+
+    return commands
+  }
+
+  private func highlightAttributes ( for item: MenuItem ) -> ColorPair {
+    return item.isHighlighted ? highlightStyle : dimHighlightStyle
+  }
+}

--- a/Sources/CodexTUI/Components/Overlay.swift
+++ b/Sources/CodexTUI/Components/Overlay.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct Overlay : Widget {
+  public var content : AnyWidget
+  public var bounds  : BoxBounds
+
+  public init ( bounds: BoxBounds, content: AnyWidget ) {
+    self.bounds  = bounds
+    self.content = content
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    let childContext = LayoutContext(bounds: bounds, theme: context.theme, focus: context.focus, environment: context.environment)
+    let childLayout  = content.layout(in: childContext)
+    return WidgetLayoutResult(bounds: bounds, commands: childLayout.commands, children: childLayout.children)
+  }
+}

--- a/Sources/CodexTUI/Components/Scaffold.swift
+++ b/Sources/CodexTUI/Components/Scaffold.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public struct Scaffold : Widget {
+  public var menuBar   : MenuBar?
+  public var content   : AnyWidget
+  public var statusBar : StatusBar?
+
+  public init ( menuBar: MenuBar? = nil, content: AnyWidget, statusBar: StatusBar? = nil ) {
+    self.menuBar   = menuBar
+    self.content   = content
+    self.statusBar = statusBar
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    var children = [WidgetLayoutResult]()
+    let rootBounds = context.bounds
+
+    var contentTop    = rootBounds.row
+    var contentBottom = rootBounds.maxRow
+
+    if let menuBar = menuBar {
+      let menuBounds  = BoxBounds(row: rootBounds.row, column: rootBounds.column, width: rootBounds.width, height: 1)
+      let menuContext = LayoutContext(bounds: menuBounds, theme: context.theme, focus: context.focus, environment: context.environment)
+      let menuLayout  = menuBar.layout(in: menuContext)
+      children.append(menuLayout)
+      contentTop += 1
+    }
+
+    if let statusBar = statusBar {
+      let statusBounds  = BoxBounds(row: rootBounds.maxRow, column: rootBounds.column, width: rootBounds.width, height: 1)
+      let statusContext = LayoutContext(bounds: statusBounds, theme: context.theme, focus: context.focus, environment: context.environment)
+      let statusLayout  = statusBar.layout(in: statusContext)
+      children.append(statusLayout)
+      contentBottom -= 1
+    }
+
+    if contentBottom < contentTop {
+      contentBottom = contentTop
+    }
+
+    let contentBounds = BoxBounds(row: contentTop, column: rootBounds.column, width: rootBounds.width, height: max(0, contentBottom - contentTop + 1))
+    let contentContext = LayoutContext(bounds: contentBounds, theme: context.theme, focus: context.focus, environment: context.environment)
+    let contentLayout  = content.layout(in: contentContext)
+    children.append(contentLayout)
+
+    return WidgetLayoutResult(bounds: rootBounds, children: children)
+  }
+}

--- a/Sources/CodexTUI/Components/StatusBar.swift
+++ b/Sources/CodexTUI/Components/StatusBar.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+public enum StatusItemAlignment {
+  case leading
+  case trailing
+}
+
+public struct StatusItem : Equatable {
+  public var text      : String
+  public var alignment : StatusItemAlignment
+
+  public init ( text: String, alignment: StatusItemAlignment = .leading ) {
+    self.text      = text
+    self.alignment = alignment
+  }
+}
+
+public struct StatusBar : Widget {
+  public var items : [StatusItem]
+  public var style : ColorPair
+
+  public init ( items: [StatusItem], style: ColorPair ) {
+    self.items = items
+    self.style = style
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    var commands = [RenderCommand]()
+    let row      = context.bounds.maxRow
+
+    var leftColumn  = context.bounds.column
+    var rightColumn = context.bounds.maxCol
+
+    for item in items where item.alignment == .leading {
+      commands.append(contentsOf: render(item: item, row: row, column: leftColumn))
+      leftColumn += item.text.count + 1
+    }
+
+    for item in items.reversed() where item.alignment == .trailing {
+      rightColumn -= item.text.count
+      commands.append(contentsOf: render(item: item, row: row, column: rightColumn))
+      rightColumn -= 1
+    }
+
+    return WidgetLayoutResult(bounds: BoxBounds(row: row, column: context.bounds.column, width: context.bounds.width, height: 1), commands: commands)
+  }
+
+  private func render ( item: StatusItem, row: Int, column: Int ) -> [RenderCommand] {
+    var commands = [RenderCommand]()
+
+    for (offset, character) in item.text.enumerated() {
+      commands.append(
+        RenderCommand(
+          row   : row,
+          column: column + offset,
+          tile  : SurfaceTile(
+            character : character,
+            attributes: style
+          )
+        )
+      )
+    }
+
+    return commands
+  }
+}

--- a/Sources/CodexTUI/Components/Text.swift
+++ b/Sources/CodexTUI/Components/Text.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct Text : Widget {
+  public var content : String
+  public var origin  : (row: Int, column: Int)
+  public var style   : ColorPair
+
+  public init ( _ content: String, origin: (row: Int, column: Int), style: ColorPair = ColorPair() ) {
+    self.content  = content
+    self.origin   = origin
+    self.style    = style
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    let bounds = BoxBounds(row: origin.row, column: origin.column, width: content.count, height: 1)
+    var commands = [RenderCommand]()
+    commands.reserveCapacity(content.count)
+
+    for (offset, character) in content.enumerated() {
+      commands.append(
+        RenderCommand(
+          row   : origin.row,
+          column: origin.column + offset,
+          tile  : SurfaceTile(
+            character : character,
+            attributes: style
+          )
+        )
+      )
+    }
+
+    return WidgetLayoutResult(bounds: bounds, commands: commands)
+  }
+}

--- a/Sources/CodexTUI/Components/TextBuffer.swift
+++ b/Sources/CodexTUI/Components/TextBuffer.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public final class TextBuffer : FocusableWidget {
+  public var focusIdentifier : FocusIdentifier
+  public var lines           : [String]
+  public var scrollOffset    : Int
+  public var style           : ColorPair
+  public var highlightStyle  : ColorPair
+  public var isInteractive   : Bool
+
+  public init ( identifier: FocusIdentifier, lines: [String] = [], scrollOffset: Int = 0, style: ColorPair = ColorPair(), highlightStyle: ColorPair = ColorPair(), isInteractive: Bool = false ) {
+    self.focusIdentifier = identifier
+    self.lines           = lines
+    self.scrollOffset    = scrollOffset
+    self.style           = style
+    self.highlightStyle  = highlightStyle
+    self.isInteractive   = isInteractive
+  }
+
+  public func focusNode () -> FocusNode {
+    return FocusNode(identifier: focusIdentifier, isEnabled: isInteractive, acceptsTab: true)
+  }
+
+  public func append ( line: String ) {
+    lines.append(line)
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    let bounds    = context.bounds.inset(by: context.environment.contentInsets)
+    let maxLines  = max(0, bounds.height)
+    let startLine = max(0, min(lines.count - maxLines, scrollOffset))
+    var commands  = [RenderCommand]()
+
+    for visibleIndex in 0..<maxLines {
+      let lineIndex = startLine + visibleIndex
+      guard lineIndex < lines.count else { break }
+      let line = lines[lineIndex]
+      let row  = bounds.row + visibleIndex
+
+      for (columnOffset, character) in line.enumerated() where columnOffset < bounds.width {
+        let column = bounds.column + columnOffset
+        commands.append(
+          RenderCommand(
+            row   : row,
+            column: column,
+            tile  : SurfaceTile(
+              character : character,
+              attributes: style
+            )
+          )
+        )
+      }
+    }
+
+    return WidgetLayoutResult(bounds: bounds, commands: commands)
+  }
+}

--- a/Sources/CodexTUI/Components/Widget.swift
+++ b/Sources/CodexTUI/Components/Widget.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+public struct RenderCommand : Equatable {
+  public var row    : Int
+  public var column : Int
+  public var tile   : SurfaceTile
+
+  public init ( row: Int, column: Int, tile: SurfaceTile ) {
+    self.row    = row
+    self.column = column
+    self.tile   = tile
+  }
+}
+
+public struct WidgetLayoutResult {
+  public var bounds   : BoxBounds
+  public var commands : [RenderCommand]
+  public var children : [WidgetLayoutResult]
+
+  public init ( bounds: BoxBounds, commands: [RenderCommand] = [], children: [WidgetLayoutResult] = [] ) {
+    self.bounds   = bounds
+    self.commands = commands
+    self.children = children
+  }
+
+  public func flattenedCommands () -> [RenderCommand] {
+    var combined = commands
+
+    for child in children {
+      combined.append(contentsOf: child.flattenedCommands())
+    }
+
+    return combined
+  }
+}
+
+public protocol Widget {
+  func layout ( in context: LayoutContext ) -> WidgetLayoutResult
+}
+
+public struct AnyWidget : Widget {
+  private let layoutClosure : (LayoutContext) -> WidgetLayoutResult
+
+  public init <Wrapped: Widget> ( _ wrapped: Wrapped ) {
+    self.layoutClosure = wrapped.layout(in:)
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    return layoutClosure(context)
+  }
+}
+
+public protocol FocusableWidget : Widget {
+  var focusIdentifier : FocusIdentifier { get }
+  func focusNode () -> FocusNode
+}
+
+public protocol OverlayPresentingWidget : Widget {
+  var presentedOverlays : [AnyWidget] { get }
+}

--- a/Sources/CodexTUI/Input/FocusChain.swift
+++ b/Sources/CodexTUI/Input/FocusChain.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+public struct FocusIdentifier : Hashable, Equatable {
+  public let rawValue : String
+
+  public init ( _ rawValue: String ) {
+    self.rawValue = rawValue
+  }
+}
+
+public struct FocusNode : Equatable {
+  public let identifier : FocusIdentifier
+  public var isEnabled  : Bool
+  public var acceptsTab : Bool
+
+  public init ( identifier: FocusIdentifier, isEnabled: Bool = true, acceptsTab: Bool = true ) {
+    self.identifier = identifier
+    self.isEnabled  = isEnabled
+    self.acceptsTab = acceptsTab
+  }
+}
+
+public final class FocusChain {
+  public private(set) var nodes  : [FocusNode]
+  public private(set) var active : FocusIdentifier?
+
+  public init ( nodes: [FocusNode] = [] ) {
+    self.nodes  = nodes
+    self.active = nodes.first?.identifier
+  }
+
+  public func snapshot () -> Snapshot {
+    return Snapshot(nodes: nodes, active: active)
+  }
+
+  public func focus ( identifier: FocusIdentifier ) {
+    guard nodes.contains(where: { $0.identifier == identifier && $0.isEnabled }) else { return }
+    active = identifier
+  }
+
+  public func advance () {
+    guard nodes.isEmpty == false else { return }
+
+    let enabled = nodes.enumerated().filter { $0.element.isEnabled }
+    guard enabled.isEmpty == false else { return }
+
+    if let active = active, let index = enabled.firstIndex(where: { $0.element.identifier == active }) {
+      let nextIndex = enabled[(index + 1) % enabled.count].offset
+      self.active   = nodes[nextIndex].identifier
+      return
+    }
+
+    self.active = enabled.first?.element.identifier
+  }
+
+  public func retreat () {
+    guard nodes.isEmpty == false else { return }
+
+    let enabled = nodes.enumerated().filter { $0.element.isEnabled }
+    guard enabled.isEmpty == false else { return }
+
+    if let active = active, let index = enabled.firstIndex(where: { $0.element.identifier == active }) {
+      let previousIndex = (index - 1 + enabled.count) % enabled.count
+      let nodeIndex     = enabled[previousIndex].offset
+      self.active       = nodes[nodeIndex].identifier
+      return
+    }
+
+    self.active = enabled.last?.element.identifier
+  }
+
+  public func register ( node: FocusNode ) {
+    guard nodes.contains(where: { $0.identifier == node.identifier }) == false else { return }
+    nodes.append(node)
+    if active == nil { active = node.identifier }
+  }
+
+  public func unregister ( identifier: FocusIdentifier ) {
+    nodes.removeAll { $0.identifier == identifier }
+    if active == identifier { active = nodes.first?.identifier }
+  }
+
+  public struct Snapshot {
+    public let nodes  : [FocusNode]
+    public let active : FocusIdentifier?
+  }
+}

--- a/Sources/CodexTUI/Input/KeyEvent.swift
+++ b/Sources/CodexTUI/Input/KeyEvent.swift
@@ -1,0 +1,57 @@
+import Foundation
+import TerminalInput
+
+public struct KeyEvent : Equatable {
+  public var key       : Key
+  public var modifiers : KeyModifiers
+
+  public init ( key: Key, modifiers: KeyModifiers = [] ) {
+    self.key       = key
+    self.modifiers = modifiers
+  }
+}
+
+public enum Key : Equatable {
+  case character(Character)
+  case control(TerminalInput.ControlKey)
+  case cursor(TerminalInput.CursorKey)
+  case function(TerminalInput.FunctionKey)
+  case meta(TerminalInput.MetaKey)
+}
+
+public struct KeyModifiers : OptionSet, Equatable {
+  public let rawValue : UInt8
+
+  public init ( rawValue: UInt8 ) {
+    self.rawValue = rawValue
+  }
+
+  public static let control : KeyModifiers = KeyModifiers(rawValue: 1 << 0)
+  public static let option  : KeyModifiers = KeyModifiers(rawValue: 1 << 1)
+  public static let shift   : KeyModifiers = KeyModifiers(rawValue: 1 << 2)
+}
+
+public extension KeyEvent {
+  static func from ( token: TerminalInput.Token ) -> KeyEvent? {
+    switch token {
+      case .text(let string) where string.count == 1:
+        guard let character = string.first else { return nil }
+        return KeyEvent(key: .character(character))
+
+      case .control(let control):
+        return KeyEvent(key: .control(control))
+
+      case .cursor(let cursor):
+        return KeyEvent(key: .cursor(cursor))
+
+      case .function(let function):
+        return KeyEvent(key: .function(function))
+
+      case .meta(let meta):
+        return KeyEvent(key: .meta(meta), modifiers: [.option])
+
+      default:
+        return nil
+    }
+  }
+}

--- a/Sources/CodexTUI/Layout/BoxBounds.swift
+++ b/Sources/CodexTUI/Layout/BoxBounds.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+public struct BoxBounds : Equatable {
+  public var row    : Int
+  public var column : Int
+  public var width  : Int
+  public var height : Int
+
+  public init ( row: Int, column: Int, width: Int, height: Int ) {
+    self.row    = row
+    self.column = column
+    self.width  = width
+    self.height = height
+  }
+
+  public var minRow : Int { row }
+  public var maxRow : Int { row + height - 1 }
+  public var minCol : Int { column }
+  public var maxCol : Int { column + width - 1 }
+
+  public var area : Int { max(0, width * height) }
+
+  public func inset ( by insets: EdgeInsets ) -> BoxBounds {
+    let insetRow    = row + insets.top
+    let insetColumn = column + insets.leading
+    let insetWidth  = max(0, width - insets.horizontal)
+    let insetHeight = max(0, height - insets.vertical)
+
+    return BoxBounds(row: insetRow, column: insetColumn, width: insetWidth, height: insetHeight)
+  }
+
+  public func aligned ( horizontal: HorizontalAlignment, vertical: VerticalAlignment, inside container: BoxBounds ) -> BoxBounds {
+    let originRow : Int
+    let originCol : Int
+
+    switch vertical {
+      case .top    : originRow = container.row
+      case .center : originRow = container.row + (container.height - height) / 2
+      case .bottom : originRow = container.maxRow - height + 1
+    }
+
+    switch horizontal {
+      case .leading  : originCol = container.column
+      case .center   : originCol = container.column + (container.width - width) / 2
+      case .trailing : originCol = container.maxCol - width + 1
+    }
+
+    return BoxBounds(row: originRow, column: originCol, width: width, height: height)
+  }
+}
+
+public struct EdgeInsets : Equatable {
+  public var top      : Int
+  public var leading  : Int
+  public var bottom   : Int
+  public var trailing : Int
+
+  public init ( top: Int = 0, leading: Int = 0, bottom: Int = 0, trailing: Int = 0 ) {
+    self.top      = top
+    self.leading  = leading
+    self.bottom   = bottom
+    self.trailing = trailing
+  }
+
+  public var horizontal : Int { leading + trailing }
+  public var vertical   : Int { top + bottom }
+}
+
+public enum HorizontalAlignment {
+  case leading
+  case center
+  case trailing
+}
+
+public enum VerticalAlignment {
+  case top
+  case center
+  case bottom
+}

--- a/Sources/CodexTUI/Layout/LayoutContext.swift
+++ b/Sources/CodexTUI/Layout/LayoutContext.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct LayoutContext {
+  public var bounds       : BoxBounds
+  public var theme        : Theme
+  public var focus        : FocusChain.Snapshot
+  public var environment  : EnvironmentValues
+
+  public init ( bounds: BoxBounds, theme: Theme, focus: FocusChain.Snapshot, environment: EnvironmentValues = EnvironmentValues() ) {
+    self.bounds      = bounds
+    self.theme       = theme
+    self.focus       = focus
+    self.environment = environment
+  }
+}
+
+public struct EnvironmentValues {
+  public var menuBarHeight   : Int
+  public var statusBarHeight : Int
+  public var contentInsets   : EdgeInsets
+
+  public init ( menuBarHeight: Int = 1, statusBarHeight: Int = 1, contentInsets: EdgeInsets = EdgeInsets() ) {
+    self.menuBarHeight   = menuBarHeight
+    self.statusBarHeight = statusBarHeight
+    self.contentInsets   = contentInsets
+  }
+}

--- a/Sources/CodexTUI/Platform/SignalHandling.swift
+++ b/Sources/CodexTUI/Platform/SignalHandling.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Dispatch
+
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+public final class SignalObserver {
+  public typealias Handler = () -> Void
+
+  private let monitoredSignal : Int32
+  private let queue           : DispatchQueue
+  private var source          : DispatchSourceSignal?
+  private var handler         : Handler?
+
+  public init ( signal: Int32 = SIGWINCH, queue: DispatchQueue = .main ) {
+    self.monitoredSignal = signal
+    self.queue           = queue
+  }
+
+  public func setHandler ( _ handler: @escaping Handler ) {
+    self.handler = handler
+  }
+
+  public func start () {
+    guard source == nil else { return }
+
+    signal(monitoredSignal, SIG_IGN)
+
+    let source = DispatchSource.makeSignalSource(signal: monitoredSignal, queue: queue)
+    source.setEventHandler { [weak self] in
+      self?.handler?()
+    }
+    source.resume()
+
+    self.source = source
+    signal(monitoredSignal, SIG_IGN)
+  }
+
+  public func stop () {
+    source?.cancel()
+    source = nil
+    handler = nil
+  }
+
+  deinit {
+    stop()
+  }
+}

--- a/Sources/CodexTUI/Rendering/Surface.swift
+++ b/Sources/CodexTUI/Rendering/Surface.swift
@@ -1,0 +1,130 @@
+import Foundation
+import TerminalOutput
+
+public struct SurfaceTile : Equatable {
+  public var character  : Character
+  public var attributes : ColorPair
+
+  public init ( character: Character, attributes: ColorPair ) {
+    self.character  = character
+    self.attributes = attributes
+  }
+}
+
+public extension SurfaceTile {
+  static let blank : SurfaceTile = SurfaceTile(character: " ", attributes: ColorPair())
+}
+
+public struct Surface {
+  public private(set) var width    : Int
+  public private(set) var height   : Int
+  private var tiles                : [SurfaceTile]
+  private var previousFrameTiles   : [SurfaceTile]
+
+  public init ( width: Int, height: Int ) {
+    let count  = max(0, width * height)
+    let filler = SurfaceTile.blank
+
+    self.width              = width
+    self.height             = height
+    self.tiles              = Array(repeating: filler, count: count)
+    self.previousFrameTiles = Array(repeating: filler, count: count)
+  }
+
+  public mutating func resize ( width: Int, height: Int ) {
+    guard self.width != width || self.height != height else { return }
+
+    self.width  = width
+    self.height = height
+
+    let count = max(0, width * height)
+    tiles              = Array(repeating: .blank, count: count)
+    previousFrameTiles = Array(repeating: .blank, count: count)
+  }
+
+  public mutating func clear ( with tile: SurfaceTile = .blank ) {
+    tiles = Array(repeating: tile, count: tiles.count)
+  }
+
+  public func tile ( atRow row: Int, column: Int ) -> SurfaceTile? {
+    guard isValid(row: row, column: column) else { return nil }
+    let index = indexFor(row: row, column: column)
+    return tiles[index]
+  }
+
+  public mutating func set ( tile: SurfaceTile, atRow row: Int, column: Int ) {
+    guard isValid(row: row, column: column) else { return }
+    tiles[indexFor(row: row, column: column)] = tile
+  }
+
+  public mutating func beginFrame () {
+    previousFrameTiles = tiles
+  }
+
+  public func diff () -> [SurfaceChange] {
+    guard tiles.count == previousFrameTiles.count else { return fullRefreshChanges() }
+
+    var changes = [SurfaceChange]()
+    changes.reserveCapacity(tiles.count / 2)
+
+    for index in tiles.indices where tiles[index] != previousFrameTiles[index] {
+      let row    = index / width
+      let column = index % width
+      changes.append(SurfaceChange(row: row + 1, column: column + 1, tile: tiles[index]))
+    }
+
+    return changes
+  }
+
+  private func fullRefreshChanges () -> [SurfaceChange] {
+    var changes = [SurfaceChange]()
+    changes.reserveCapacity(tiles.count)
+
+    for index in tiles.indices {
+      let row    = index / width
+      let column = index % width
+      changes.append(SurfaceChange(row: row + 1, column: column + 1, tile: tiles[index]))
+    }
+
+    return changes
+  }
+
+  private func isValid ( row: Int, column: Int ) -> Bool {
+    return row >= 1 && column >= 1 && row <= height && column <= width
+  }
+
+  private func indexFor ( row: Int, column: Int ) -> Int {
+    return (row - 1) * width + (column - 1)
+  }
+}
+
+public struct SurfaceChange : Equatable {
+  public let row    : Int
+  public let column : Int
+  public let tile   : SurfaceTile
+}
+
+public enum SurfaceRenderer {
+  public static func sequences ( for changes: [SurfaceChange] ) -> [AnsiSequence] {
+    guard changes.isEmpty == false else { return [] }
+
+    var sequences = [AnsiSequence]()
+    sequences.reserveCapacity(changes.count * 3)
+
+    for change in changes {
+      sequences.append(TerminalOutput.TerminalCommands.moveCursor(row: change.row, column: change.column))
+
+      if let sequence = change.tile.attributes.style.openingSequence(foreground: change.tile.attributes.foreground, background: change.tile.attributes.background) {
+        sequences.append(sequence)
+      }
+
+      sequences.append(AnsiSequence(rawValue: String(change.tile.character)))
+
+      if change.tile.attributes.style.requiresReset {
+        sequences.append(TerminalOutput.TextStyle.resetSequence())
+      }
+    }
+
+    return sequences
+  }
+}

--- a/Sources/CodexTUI/Scenes/Scene.swift
+++ b/Sources/CodexTUI/Scenes/Scene.swift
@@ -1,0 +1,76 @@
+import Foundation
+import TerminalOutput
+
+public struct SceneConfiguration {
+  public var theme        : Theme
+  public var environment  : EnvironmentValues
+  public var showMenuBar  : Bool
+  public var showStatusBar: Bool
+
+  public init ( theme: Theme = .codex, environment: EnvironmentValues = EnvironmentValues(), showMenuBar: Bool = true, showStatusBar: Bool = true ) {
+    self.theme         = theme
+    self.environment   = environment
+    self.showMenuBar   = showMenuBar
+    self.showStatusBar = showStatusBar
+  }
+}
+
+public final class Scene {
+  public var configuration : SceneConfiguration
+  public var focusChain    : FocusChain
+  public var rootWidget    : AnyWidget
+  public var overlays      : [AnyWidget]
+
+  public init ( configuration: SceneConfiguration = SceneConfiguration(), focusChain: FocusChain = FocusChain(), rootWidget: AnyWidget, overlays: [AnyWidget] = [] ) {
+    self.configuration = configuration
+    self.focusChain    = focusChain
+    self.rootWidget    = rootWidget
+    self.overlays      = overlays
+  }
+
+  public func registerFocusable ( _ widget: FocusableWidget ) {
+    focusChain.register(node: widget.focusNode())
+  }
+
+  public func layoutContext ( for bounds: BoxBounds ) -> LayoutContext {
+    return LayoutContext(bounds: bounds, theme: configuration.theme, focus: focusChain.snapshot(), environment: configuration.environment)
+  }
+
+  public func render ( into surface: inout Surface, bounds: BoxBounds ) -> [AnsiSequence] {
+    surface.beginFrame()
+    surface.resize(
+      width  : bounds.width,
+      height : bounds.height
+    )
+    surface.clear()
+
+    let context     = layoutContext(for: bounds)
+    let rootLayout  = rootWidget.layout(in: context)
+    var allCommands = rootLayout.flattenedCommands()
+
+    for overlay in overlays {
+      let overlayLayout = overlay.layout(in: context)
+      allCommands.append(contentsOf: overlayLayout.flattenedCommands())
+    }
+
+    for command in allCommands {
+      surface.set(
+        tile   : command.tile,
+        atRow  : command.row,
+        column : command.column
+      )
+    }
+
+    let changes = surface.diff()
+    return SurfaceRenderer.sequences(for: changes)
+  }
+}
+
+public extension Scene {
+  static func standard ( menuBar: MenuBar? = nil, content: AnyWidget, statusBar: StatusBar? = nil, configuration: SceneConfiguration = SceneConfiguration(), focusChain: FocusChain = FocusChain(), overlays: [AnyWidget] = [] ) -> Scene {
+    let scaffold    = Scaffold(menuBar: menuBar, content: content, statusBar: statusBar)
+    let rootWidget  = AnyWidget(scaffold)
+    let scene       = Scene(configuration: configuration, focusChain: focusChain, rootWidget: rootWidget, overlays: overlays)
+    return scene
+  }
+}

--- a/Sources/CodexTUI/Styling/Theme.swift
+++ b/Sources/CodexTUI/Styling/Theme.swift
@@ -1,0 +1,56 @@
+import Foundation
+import TerminalOutput
+
+public struct ColorPair : Equatable {
+  public var foreground : TerminalOutput.Color?
+  public var background : TerminalOutput.Color?
+  public var style      : TerminalOutput.TextStyle
+
+  public init ( foreground: TerminalOutput.Color? = nil, background: TerminalOutput.Color? = nil, style: TerminalOutput.TextStyle = .none ) {
+    self.foreground = foreground
+    self.background = background
+    self.style      = style
+  }
+}
+
+public func == ( lhs: ColorPair, rhs: ColorPair ) -> Bool {
+  let foregroundEqual = lhs.foreground?.index == rhs.foreground?.index
+  let backgroundEqual = lhs.background?.index == rhs.background?.index
+  return foregroundEqual && backgroundEqual && lhs.style == rhs.style
+}
+
+public struct Theme : Equatable {
+  public var menuBar        : ColorPair
+  public var statusBar      : ColorPair
+  public var windowChrome   : ColorPair
+  public var contentDefault : ColorPair
+  public var highlight      : ColorPair
+  public var dimHighlight   : ColorPair
+
+  public init (
+    menuBar: ColorPair = Theme.defaultMenuBar,
+    statusBar: ColorPair = Theme.defaultStatusBar,
+    windowChrome: ColorPair = Theme.defaultWindowChrome,
+    contentDefault: ColorPair = Theme.defaultContent,
+    highlight: ColorPair = Theme.defaultHighlight,
+    dimHighlight: ColorPair = Theme.defaultDimHighlight
+  ) {
+    self.menuBar        = menuBar
+    self.statusBar      = statusBar
+    self.windowChrome   = windowChrome
+    self.contentDefault = contentDefault
+    self.highlight      = highlight
+    self.dimHighlight   = dimHighlight
+  }
+}
+
+public extension Theme {
+  static let codex : Theme = Theme()
+
+  static let defaultMenuBar      : ColorPair = ColorPair(foreground: .white, background: .blue, style: [.bold])
+  static let defaultStatusBar    : ColorPair = ColorPair(foreground: .white, background: .magenta, style: [.bold])
+  static let defaultWindowChrome : ColorPair = ColorPair(foreground: .white, background: .black)
+  static let defaultContent      : ColorPair = ColorPair(foreground: .white, background: .black)
+  static let defaultHighlight    : ColorPair = ColorPair(foreground: .black, background: .yellow, style: [.bold])
+  static let defaultDimHighlight : ColorPair = ColorPair(foreground: .black, background: .yellow, style: [.dim])
+}

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -1,4 +1,48 @@
 import XCTest
+import TerminalOutput
 @testable import CodexTUI
 
+final class CodexTUITests: XCTestCase {
+  func testSurfaceDiffDetectsChanges () {
+    var surface = Surface(width: 4, height: 2)
+    surface.beginFrame()
+    surface.clear()
+    surface.set(tile: SurfaceTile(character: "A", attributes: ColorPair()), atRow: 1, column: 1)
 
+    let changes = surface.diff()
+    XCTAssertEqual(changes.count, 1)
+    XCTAssertEqual(changes.first?.row, 1)
+    XCTAssertEqual(changes.first?.column, 1)
+  }
+
+  func testFocusChainAdvancesAndWraps () {
+    let identifierA = FocusIdentifier("a")
+    let identifierB = FocusIdentifier("b")
+    let nodeA       = FocusNode(identifier: identifierA)
+    let nodeB       = FocusNode(identifier: identifierB)
+    let chain       = FocusChain(nodes: [nodeA, nodeB])
+
+    XCTAssertEqual(chain.active, identifierA)
+
+    chain.advance()
+    XCTAssertEqual(chain.active, identifierB)
+
+    chain.advance()
+    XCTAssertEqual(chain.active, identifierA)
+  }
+
+  func testSceneRendersText () throws {
+    let text      = Text("Hello", origin: (row: 1, column: 1))
+    let content   = AnyWidget(text)
+    let scene     = Scene.standard(content: content)
+    var surface   = Surface(width: 10, height: 3)
+    let bounds    = BoxBounds(row: 1, column: 1, width: 10, height: 3)
+
+    let sequences = scene.render(into: &surface, bounds: bounds)
+
+    XCTAssertFalse(sequences.isEmpty)
+    let firstTile = surface.tile(atRow: 1, column: 1)
+    XCTAssertEqual(firstTile.map { String($0.character) }, "H")
+    XCTAssertEqual(firstTile?.attributes.style, TerminalOutput.TextStyle.none)
+  }
+}


### PR DESCRIPTION
## Summary
- add styling, layout, rendering, and input primitives that provide the building blocks for CodexTUI widgets
- implement the terminal driver, scene management pipeline, and a convenience factory for creating configured drivers
- introduce initial widgets (text, box, menu bar, status bar, text buffer, overlays) and accompanying unit tests to verify rendering and focus behavior

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e439eda9a08328a196e1ed9bc1f6b7