### PR TITLE
Update quick start to use CodexTUI APIs and add demo executable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,9 @@ let package = Package(
         .library(
             name: "CodexTUI",
             targets: ["CodexTUI"]),
+        .executable(
+            name: "CodexTUIDemo",
+            targets: ["CodexTUIDemo"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -27,6 +30,9 @@ let package = Package(
         .target(
             name: "CodexTUI",
             dependencies: ["TerminalInput", "TerminalOutput"]),
+        .executableTarget(
+            name: "CodexTUIDemo",
+            dependencies: ["CodexTUI"]),
         .testTarget(
             name: "CodexTUITests",
             dependencies: ["CodexTUI"]),

--- a/README.md
+++ b/README.md
@@ -71,67 +71,119 @@ Understanding these pillars will help you diagnose layout issues, extend widgets
 
 ## Quick Start Demo
 
-The following minimal example shows how to wire up a main screen with a menu bar, status bar, and scrollable log window. It also demonstrates how to open a modal message box via a keyboard shortcut.
+The following minimal example shows how to compose a scene with a menu bar, status bar, and scrolling text buffer using the core CodexTUI types. It also demonstrates how to drive the terminal directly via `TerminalDriver`.
 
 ```swift
 import CodexTUI
+import Dispatch
 import Foundation
+import TerminalInput
 
-final class DemoController {
-    private let app: Application
-    private let logBuffer = ScrollBuffer()
+final class DemoApplication {
+  private let driver    : TerminalDriver
+  private let logBuffer : TextBuffer
+  private let waitGroup : DispatchSemaphore
 
-    init() {
-        app = Application(
-            menuBar: MenuBar(items: [
-                MenuItem(key: "F", title: "File", alignment: .leading) {
-                    MessageBox(
-                        title: "File",
-                        message: ["New", "Open", "Save"],
-                        buttons: ["Close"]
-                    )
-                }
-            ]),
-            statusBar: StatusBar(items: [
-                StatusItem(text: "Press Ctrl+Q to quit", alignment: .leading),
-                StatusItem(text: DateFormatter.localizedString(from: Date(), dateStyle: .short, timeStyle: .short), alignment: .trailing)
-            ]),
-            content: SplitView(
-                orientation: .vertical,
-                leading: TextView(title: "Activity", buffer: logBuffer),
-                trailing: TextView(title: "Details", buffer: ScrollBuffer())
-            )
-        )
+  private static let timestampFormatter : DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .short
+    formatter.timeStyle = .medium
+    return formatter
+  }()
 
-        app.bind(key: .control("q")) { [weak self] in self?.app.stop() }
-        app.bind(key: .function(2)) { [weak self] in self?.showInfoBox() }
+  init () {
+    let theme = Theme.codex
+
+    logBuffer = TextBuffer(
+      identifier    : FocusIdentifier("log"),
+      lines         : [
+        "CodexTUI quick start",
+        "Press any key to log it.",
+        "Press ESC to exit."
+      ],
+      style         : theme.contentDefault,
+      highlightStyle: theme.highlight,
+      isInteractive : true
+    )
+
+    waitGroup = DispatchSemaphore(value: 0)
+
+    let menuBar = MenuBar(
+      items            : [
+        MenuItem(title: "File", activationKey: .TAB, alignment: .leading, isHighlighted: true),
+        MenuItem(title: "Help", activationKey: .RETURN, alignment: .trailing)
+      ],
+      style            : theme.menuBar,
+      highlightStyle   : theme.highlight,
+      dimHighlightStyle: theme.dimHighlight
+    )
+
+    let statusBar = StatusBar(
+      items: [
+        StatusItem(text: "ESC closes the demo"),
+        StatusItem(text: DemoApplication.timestamp(), alignment: .trailing)
+      ],
+      style: theme.statusBar
+    )
+
+    let focusChain = FocusChain()
+    focusChain.register(node: logBuffer.focusNode())
+
+    let configuration = SceneConfiguration(
+      theme       : theme,
+      environment : EnvironmentValues(contentInsets: EdgeInsets(top: 1, leading: 2, bottom: 1, trailing: 2))
+    )
+
+    let scene = Scene.standard(
+      menuBar     : menuBar,
+      content     : AnyWidget(logBuffer),
+      statusBar   : statusBar,
+      configuration: configuration,
+      focusChain  : focusChain
+    )
+
+    driver = CodexTUI.makeDriver(scene: scene)
+
+    driver.onKeyEvent = { [weak self] event in
+      self?.handle(event: event)
     }
+  }
 
-    func run() {
-        logBuffer.append("CodexTUI demo started")
-        app.run()
-    }
+  func run () {
+    driver.start()
+    waitGroup.wait()
+  }
 
-    private func showInfoBox() {
-        app.present(
-            MessageBox(
-                title: "CodexTUI",
-                message: ["Build expressive TUIs in Swift."],
-                buttons: ["OK"]
-            )
-        )
+  private func handle ( event: KeyEvent ) {
+    switch event.key {
+      case .meta(.escape)           :
+        driver.stop()
+        waitGroup.signal()
+
+      case .character(let character)           :
+        logBuffer.append(line: "Key pressed: \(character)")
+        driver.redraw()
+
+      default                       :
+        break
     }
+  }
+
+  private static func timestamp () -> String {
+    return timestampFormatter.string(from: Date())
+  }
 }
 
-DemoController().run()
+DemoApplication().run()
 ```
 
 This sample demonstrates:
 
-- Declaring menu and status bars with alignment-aware items.
-- Connecting keyboard accelerators to application actions.
-- Displaying modal overlays that capture input focus.
-- Streaming text into scrollable buffers for live output.
+- Instantiating `MenuBar` and `StatusBar` with the active theme's colour pairs.
+- Registering a focusable `TextBuffer` and embedding it inside a standard `Scene`.
+- Bootstrapping a `TerminalDriver` using `CodexTUI.makeDriver(scene:)`.
+- Responding to keyboard events manually, including triggering redraws and graceful shutdown.
+- Keeping the process alive with a `DispatchSemaphore` until the user exits.
 
 ## Documentation & Further Reading
 

--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -1,0 +1,101 @@
+import CodexTUI
+import Dispatch
+import Foundation
+import TerminalInput
+
+final class DemoApplication {
+  private let driver    : TerminalDriver
+  private let logBuffer : TextBuffer
+  private let waitGroup : DispatchSemaphore
+
+  private static let timestampFormatter : DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .short
+    formatter.timeStyle = .medium
+    return formatter
+  }()
+
+  init () {
+    let theme = Theme.codex
+
+    logBuffer = TextBuffer(
+      identifier    : FocusIdentifier("log"),
+      lines         : [
+        "CodexTUI quick start",
+        "Press any key to log it.",
+        "Press ESC to exit."
+      ],
+      style         : theme.contentDefault,
+      highlightStyle: theme.highlight,
+      isInteractive : true
+    )
+
+    waitGroup = DispatchSemaphore(value: 0)
+
+    let menuBar = MenuBar(
+      items            : [
+        MenuItem(title: "File", activationKey: .TAB, alignment: .leading, isHighlighted: true),
+        MenuItem(title: "Help", activationKey: .RETURN, alignment: .trailing)
+      ],
+      style            : theme.menuBar,
+      highlightStyle   : theme.highlight,
+      dimHighlightStyle: theme.dimHighlight
+    )
+
+    let statusBar = StatusBar(
+      items: [
+        StatusItem(text: "ESC closes the demo"),
+        StatusItem(text: DemoApplication.timestamp(), alignment: .trailing)
+      ],
+      style: theme.statusBar
+    )
+
+    let focusChain = FocusChain()
+    focusChain.register(node: logBuffer.focusNode())
+
+    let configuration = SceneConfiguration(
+      theme       : theme,
+      environment : EnvironmentValues(contentInsets: EdgeInsets(top: 1, leading: 2, bottom: 1, trailing: 2))
+    )
+
+    let scene = Scene.standard(
+      menuBar     : menuBar,
+      content     : AnyWidget(logBuffer),
+      statusBar   : statusBar,
+      configuration: configuration,
+      focusChain  : focusChain
+    )
+
+    driver = CodexTUI.makeDriver(scene: scene)
+
+    driver.onKeyEvent = { [weak self] event in
+      self?.handle(event: event)
+    }
+  }
+
+  func run () {
+    driver.start()
+    waitGroup.wait()
+  }
+
+  private func handle ( event: KeyEvent ) {
+    switch event.key {
+      case .meta(.escape)           :
+        driver.stop()
+        waitGroup.signal()
+
+      case .character(let character)           :
+        logBuffer.append(line: "Key pressed: \(character)")
+        driver.redraw()
+
+      default                       :
+        break
+    }
+  }
+
+  private static func timestamp () -> String {
+    return timestampFormatter.string(from: Date())
+  }
+}
+
+DemoApplication().run()


### PR DESCRIPTION
## Summary
- rewrite the README quick start example to compose a scene and terminal driver with the public CodexTUI APIs
- add a CodexTUIDemo executable target that mirrors the documented sample and uses the live library types
- expose the executable from Package.swift so it can be built alongside the library

## Testing
- swift build --product CodexTUIDemo

------
https://chatgpt.com/codex/tasks/task_e_68e44b87853c8328b04b01e243ba7622