### PR TITLE
Adjust TextBuffer scrolling after appends

### DIFF
--- a/Sources/CodexTUI/Components/TextBuffer.swift
+++ b/Sources/CodexTUI/Components/TextBuffer.swift
@@ -25,13 +25,16 @@ public final class TextBuffer : FocusableWidget {
 
   public func append ( line: String ) {
     lines.append(line)
+    scrollOffset  = max(0, lines.count - 1)
   }
 
   // Projects the text buffer into the provided bounds respecting scroll offsets and clipping.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let bounds    = context.bounds.inset(by: context.environment.contentInsets)
     let maxLines  = max(0, bounds.height)
-    let startLine = max(0, min(lines.count - maxLines, scrollOffset))
+    let maxOffset = max(0, lines.count - maxLines)
+    scrollOffset  = min(maxOffset, max(0, scrollOffset))
+    let startLine = scrollOffset
     var commands  = [RenderCommand]()
 
     // Calculate the visible slice of lines then copy characters until we hit the horizontal limit.

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -48,6 +48,28 @@ final class CodexTUITests: XCTestCase {
     XCTAssertEqual(firstTile?.attributes.style, TerminalOutput.TextStyle.none)
   }
 
+  func testTextBufferDefaultsToNewestLine () {
+    let buffer        = TextBuffer(identifier: FocusIdentifier("buffer"))
+    let focusChain    = FocusChain()
+    let focusSnapshot = focusChain.snapshot()
+    let bounds        = BoxBounds(row: 1, column: 1, width: 10, height: 2)
+    let context       = LayoutContext(bounds: bounds, theme: Theme.codex, focus: focusSnapshot)
+
+    buffer.append(line: "first")
+    buffer.append(line: "second")
+    buffer.append(line: "third")
+
+    let result      = buffer.layout(in: context)
+    let lastRow     = bounds.row + bounds.height - 1
+    let lineCommand = result.commands
+      .filter { $0.row == lastRow }
+      .sorted { $0.column < $1.column }
+    let rendered    = String(lineCommand.map { $0.tile.character })
+
+    XCTAssertEqual(buffer.scrollOffset, 1)
+    XCTAssertEqual(rendered, "third")
+  }
+
   func testDriverDeliversKeyPressImmediatelyInRawMode () {
     let connection    = TestTerminalConnection()
     let terminal      = TerminalOutput.Terminal(connection: connection)


### PR DESCRIPTION
## Summary
- update `TextBuffer.append` to advance the scroll position to the newest line
- clamp the stored scroll offset during layout to stay within the available content
- add a regression test that ensures a small viewport renders the latest appended line

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e45b1c0a1083288b7297f21b5723ef