### PR TITLE
Add printable accelerator support to menu items

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ final class DemoApplication {
 
     let menuBar = MenuBar(
       items            : [
-        MenuItem(title: "File", activationKey: .TAB, alignment: .leading, isHighlighted: true),
-        MenuItem(title: "Help", activationKey: .RETURN, alignment: .trailing)
+        MenuItem(title: "File", activationKey: MenuActivationKey(key: .character("f"), modifiers: [.option]), alignment: .leading, isHighlighted: true),
+        MenuItem(title: "Help", activationKey: MenuActivationKey(key: .character("h")), alignment: .trailing)
       ],
       style            : theme.menuBar,
       highlightStyle   : theme.highlight,

--- a/Sources/CodexTUI/Components/MenuBar.swift
+++ b/Sources/CodexTUI/Components/MenuBar.swift
@@ -1,23 +1,40 @@
 import Foundation
-import TerminalInput
 
 public enum MenuItemAlignment {
   case leading
   case trailing
 }
 
+public struct MenuActivationKey : Equatable {
+  public var key       : Key
+  public var modifiers : KeyModifiers
+
+  public init ( key: Key, modifiers: KeyModifiers = [] ) {
+    self.key       = key
+    self.modifiers = modifiers
+  }
+
+  public func matches ( event: KeyEvent ) -> Bool {
+    return event.key == key && event.modifiers == modifiers
+  }
+}
+
 // Describes a single interactive item within the menu bar.
 public struct MenuItem : Equatable {
   public var title          : String
-  public var activationKey  : TerminalInput.ControlKey
+  public var activationKey  : MenuActivationKey
   public var alignment      : MenuItemAlignment
   public var isHighlighted  : Bool
 
-  public init ( title: String, activationKey: TerminalInput.ControlKey, alignment: MenuItemAlignment = .leading, isHighlighted: Bool = false ) {
+  public init ( title: String, activationKey: MenuActivationKey, alignment: MenuItemAlignment = .leading, isHighlighted: Bool = false ) {
     self.title         = title
     self.activationKey = activationKey
     self.alignment     = alignment
     self.isHighlighted = isHighlighted
+  }
+
+  public func matches ( event: KeyEvent ) -> Bool {
+    return activationKey.matches(event: event)
   }
 }
 

--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -6,6 +6,7 @@ import TerminalInput
 final class DemoApplication {
   private let driver    : TerminalDriver
   private let logBuffer : TextBuffer
+  private let menuBar   : MenuBar
   private let waitGroup : DispatchSemaphore
 
   private static let timestampFormatter : DateFormatter = {
@@ -32,10 +33,10 @@ final class DemoApplication {
 
     waitGroup = DispatchSemaphore(value: 0)
 
-    let menuBar = MenuBar(
+    menuBar = MenuBar(
       items            : [
-        MenuItem(title: "File", activationKey: .TAB, alignment: .leading, isHighlighted: true),
-        MenuItem(title: "Help", activationKey: .RETURN, alignment: .trailing)
+        MenuItem(title: "File", activationKey: MenuActivationKey(key: .character("f"), modifiers: [.option]), alignment: .leading, isHighlighted: true),
+        MenuItem(title: "Help", activationKey: MenuActivationKey(key: .character("h")), alignment: .trailing)
       ],
       style            : theme.menuBar,
       highlightStyle   : theme.highlight,
@@ -79,6 +80,12 @@ final class DemoApplication {
   }
 
   private func handle ( event: KeyEvent ) {
+    if let item = menuBar.items.first(where: { $0.matches(event: event) }) {
+      logBuffer.append(line: "Activated menu item: \(item.title)")
+      driver.redraw()
+      return
+    }
+
     switch event.key {
       case .meta(.escape)           :
         driver.stop()

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -48,6 +48,16 @@ final class CodexTUITests: XCTestCase {
     XCTAssertEqual(firstTile?.attributes.style, TerminalOutput.TextStyle.none)
   }
 
+  func testMenuItemMatchesPrintableAccelerator () {
+    let accelerator = MenuActivationKey(key: .character("f"), modifiers: [.option])
+    let item        = MenuItem(title: "File", activationKey: accelerator)
+    let matching    = KeyEvent(key: .character("f"), modifiers: [.option])
+    let nonMatching = KeyEvent(key: .character("f"))
+
+    XCTAssertTrue(item.matches(event: matching))
+    XCTAssertFalse(item.matches(event: nonMatching))
+  }
+
   func testTextBufferDefaultsToNewestLine () {
     let buffer        = TextBuffer(identifier: FocusIdentifier("buffer"))
     let focusChain    = FocusChain()


### PR DESCRIPTION
## Summary
- add a `MenuActivationKey` helper so menu items can bind printable accelerators and expose a matching utility
- update the demo wiring (and README snippet) to register mnemonic key events and log menu activations
- cover accelerator matching with a unit test

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e45d2c81ac8328961bb3baddaed3dd