### PR TITLE
Allow menu accelerators to match meta option chords

### DIFF
--- a/Sources/CodexTUI/Components/MenuBar.swift
+++ b/Sources/CodexTUI/Components/MenuBar.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TerminalInput
 
 public enum MenuItemAlignment {
   case leading
@@ -15,7 +16,34 @@ public struct MenuActivationKey : Equatable {
   }
 
   public func matches ( event: KeyEvent ) -> Bool {
-    return event.key == key && event.modifiers == modifiers
+    if event.key == key && event.modifiers == modifiers {
+      return true
+    }
+
+    guard modifiers == event.modifiers else { return false }
+
+    guard modifiers.contains(.option) else { return false }
+
+    guard case .character(let activationCharacter) = key else { return false }
+
+    guard case .meta(let metaKey) = event.key else { return false }
+
+    guard let character = metaKey.acceleratorCharacter else { return false }
+
+    return character == activationCharacter
+  }
+}
+
+private extension TerminalInput.MetaKey {
+  var acceleratorCharacter : Character? {
+    switch self {
+      case .alt(let character):
+        return character
+
+      default:
+        guard let child = Mirror(reflecting: self).children.first else { return nil }
+        return child.value as? Character
+    }
   }
 }
 

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -49,12 +49,14 @@ final class CodexTUITests: XCTestCase {
   }
 
   func testMenuItemMatchesPrintableAccelerator () {
-    let accelerator = MenuActivationKey(key: .character("f"), modifiers: [.option])
-    let item        = MenuItem(title: "File", activationKey: accelerator)
-    let matching    = KeyEvent(key: .character("f"), modifiers: [.option])
-    let nonMatching = KeyEvent(key: .character("f"))
+    let accelerator  = MenuActivationKey(key: .character("f"), modifiers: [.option])
+    let item         = MenuItem(title: "File", activationKey: accelerator)
+    let matching     = KeyEvent(key: .character("f"), modifiers: [.option])
+    let metaMatching = KeyEvent(key: .meta(.alt("f")), modifiers: [.option])
+    let nonMatching  = KeyEvent(key: .character("f"))
 
     XCTAssertTrue(item.matches(event: matching))
+    XCTAssertTrue(item.matches(event: metaMatching))
     XCTAssertFalse(item.matches(event: nonMatching))
   }
 


### PR DESCRIPTION
## Summary
- allow printable menu accelerators to match meta option chords for the same character
- add a regression test covering meta tokens produced for option accelerators
- confirm the demo continues to bind the File menu to option+f

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e4625a56bc8328855eeeaadb6ea37d