### PR TITLE
Refine menu accelerator handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ final class DemoApplication {
 
     let menuBar = MenuBar(
       items            : [
-        MenuItem(title: "File", activationKey: MenuActivationKey(key: .character("f"), modifiers: [.option]), alignment: .leading, isHighlighted: true),
-        MenuItem(title: "Help", activationKey: MenuActivationKey(key: .character("h")), alignment: .trailing)
+        MenuItem(title: "File", activationKey: MenuActivationKey(character: "f"), alignment: .leading, isHighlighted: true),
+        MenuItem(title: "Help", activationKey: MenuActivationKey(character: "h"), alignment: .trailing)
       ],
       style            : theme.menuBar,
       highlightStyle   : theme.highlight,

--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -36,12 +36,12 @@ final class DemoApplication {
     menuBar = MenuBar(
       items            : [
         MenuItem ( title: "File",
-                   activationKey: MenuActivationKey(key: .character("f"), modifiers: [.option]),
+                   activationKey: MenuActivationKey(character: "f"),
                    alignment    : .leading,
                    isHighlighted: true
         ),
         MenuItem ( title: "Help",
-                   activationKey: MenuActivationKey(key: .character("h"), modifiers: [.option] ),
+                   activationKey: MenuActivationKey(character: "h"),
                    alignment: .trailing
       )
       ],
@@ -88,7 +88,8 @@ final class DemoApplication {
   }
 
   private func handle ( event: KeyEvent ) {
-    if let item = menuBar.items.first(where: { $0.matches(event: event) }) {
+    if let token = activationToken(for: event),
+       let item  = menuBar.items.first(where: { $0.matches(token: token) }) {
       logBuffer.append(line: "Activated menu item: \(item.title)")
       driver.redraw()
       return
@@ -110,6 +111,15 @@ final class DemoApplication {
 
   private static func timestamp () -> String {
     return timestampFormatter.string(from: Date())
+  }
+
+  private func activationToken ( for event: KeyEvent ) -> TerminalInput.Token? {
+    switch event.key {
+      case .meta(let character):
+        return .meta(.alt(character))
+      default:
+        return nil
+    }
   }
 }
 

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -49,15 +49,14 @@ final class CodexTUITests: XCTestCase {
   }
 
   func testMenuItemMatchesPrintableAccelerator () {
-    let accelerator  = MenuActivationKey(key: .character("f"), modifiers: [.option])
+    let accelerator  = MenuActivationKey(character: "f")
     let item         = MenuItem(title: "File", activationKey: accelerator)
-    
-    let metaMatching = KeyEvent(key: .meta("f"), modifiers: [.option])
-    let nonMatching  = KeyEvent(key: .character("f"))
 
-    
-    XCTAssertTrue(item.matches(event: metaMatching))
-    XCTAssertFalse(item.matches(event: nonMatching))
+    let metaMatching = TerminalInput.Token.meta(.alt("f"))
+    let nonMatching  = TerminalInput.Token.text("f")
+
+    XCTAssertTrue(item.matches(token: metaMatching))
+    XCTAssertFalse(item.matches(token: nonMatching))
   }
 
   func testTextBufferDefaultsToNewestLine () {


### PR DESCRIPTION
## Summary
- store menu activation keys as accelerator characters and match against terminal tokens
- adapt the demo, unit test, and README to the simplified activation key API
- derive menu activation tokens from key events when handling menu input

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e4e1233fe4832892624d1d3dfb0f25