### PR TITLE
Simplify menu activation key token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ final class DemoApplication {
 
     let menuBar = MenuBar(
       items            : [
-        MenuItem(title: "File", activationKey: MenuActivationKey(character: "f"), alignment: .leading, isHighlighted: true),
-        MenuItem(title: "Help", activationKey: MenuActivationKey(character: "h"), alignment: .trailing)
+        MenuItem(title: "File", activationKey: MenuActivationKey(token: .meta(.alt("f"))), alignment: .leading, isHighlighted: true),
+        MenuItem(title: "Help", activationKey: MenuActivationKey(token: .meta(.alt("h"))), alignment: .trailing)
       ],
       style            : theme.menuBar,
       highlightStyle   : theme.highlight,

--- a/Sources/CodexTUI/Components/MenuBar.swift
+++ b/Sources/CodexTUI/Components/MenuBar.swift
@@ -7,29 +7,18 @@ public enum MenuItemAlignment {
 }
 
 public struct MenuActivationKey : Equatable {
-  public var character     : Character
-  public var requiresOption: Bool
+  public var token: TerminalInput.Token
 
-  public init ( character: Character, requiresOption: Bool = true ) {
-    self.character      = character
-    self.requiresOption = requiresOption
+  public init ( token: TerminalInput.Token ) {
+    self.token = token
+  }
+
+  public init ( alt character: Character ) {
+    self.init(token: .meta(.alt(character)))
   }
 
   public func matches ( token: TerminalInput.Token ) -> Bool {
-    switch token {
-      case .meta(let meta) where requiresOption:
-        switch meta {
-          case .alt(let value):
-            return value == character
-        }
-
-      case .text(let string) where requiresOption == false && string.count == 1:
-        guard let value = string.first else { return false }
-        return value == character
-
-      default:
-        return false
-    }
+    return token == self.token
   }
 }
 

--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -36,12 +36,12 @@ final class DemoApplication {
     menuBar = MenuBar(
       items            : [
         MenuItem ( title: "File",
-                   activationKey: MenuActivationKey(character: "f"),
+                   activationKey: MenuActivationKey(token: .meta(.alt("f"))),
                    alignment    : .leading,
                    isHighlighted: true
         ),
         MenuItem ( title: "Help",
-                   activationKey: MenuActivationKey(character: "h"),
+                   activationKey: MenuActivationKey(token: .meta(.alt("h"))),
                    alignment: .trailing
       )
       ],
@@ -87,9 +87,8 @@ final class DemoApplication {
     waitGroup.wait()
   }
 
-  private func handle ( event: KeyEvent ) {
-    if let token = activationToken(for: event),
-       let item  = menuBar.items.first(where: { $0.matches(token: token) }) {
+  private func handle ( token: TerminalInput.Token ) {
+    if let item = menuBar.items.first(where: { $0.matches(token: token) }) {
       logBuffer.append(line: "Activated menu item: \(item.title)")
       driver.redraw()
       return
@@ -112,15 +111,6 @@ final class DemoApplication {
 
   private static func timestamp () -> String {
     return timestampFormatter.string(from: Date())
-  }
-
-  private func activationToken ( for event: KeyEvent ) -> TerminalInput.Token? {
-    switch event.key {
-      case .meta(let character):
-        return .meta(.alt(character))
-      default:
-        return nil
-    }
   }
 }
 

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -49,7 +49,7 @@ final class CodexTUITests: XCTestCase {
   }
 
   func testMenuItemMatchesPrintableAccelerator () {
-    let accelerator  = MenuActivationKey(character: "f")
+    let accelerator  = MenuActivationKey(token: .meta(.alt("f")))
     let item         = MenuItem(title: "File", activationKey: accelerator)
 
     let metaMatching = TerminalInput.Token.meta(.alt("f"))


### PR DESCRIPTION
## Summary
- replace `MenuActivationKey`'s stored character/option fields with a single `TerminalInput.Token` and add an Alt convenience initializer
- update the demo, README example, and tests to construct meta tokens when creating menu activation keys and to handle tokens directly

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e4e567f1888328a74fd881a0b5ce80