### PR TITLE
Simplify menu activation key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ final class DemoApplication {
 
     let menuBar = MenuBar(
       items            : [
-        MenuItem(title: "File", activationKey: MenuActivationKey(token: .meta(.alt("f"))), alignment: .leading, isHighlighted: true),
-        MenuItem(title: "Help", activationKey: MenuActivationKey(token: .meta(.alt("h"))), alignment: .trailing)
+        MenuItem(title: "File", activationKey: .meta(.alt("f")), alignment: .leading, isHighlighted: true),
+        MenuItem(title: "Help", activationKey: .meta(.alt("h")), alignment: .trailing)
       ],
       style            : theme.menuBar,
       highlightStyle   : theme.highlight,

--- a/Sources/CodexTUI/Components/MenuBar.swift
+++ b/Sources/CodexTUI/Components/MenuBar.swift
@@ -6,30 +6,14 @@ public enum MenuItemAlignment {
   case trailing
 }
 
-public struct MenuActivationKey : Equatable {
-  public var token: TerminalInput.Token
-
-  public init ( token: TerminalInput.Token ) {
-    self.token = token
-  }
-
-  public init ( alt character: Character ) {
-    self.init(token: .meta(.alt(character)))
-  }
-
-  public func matches ( token: TerminalInput.Token ) -> Bool {
-    return token == self.token
-  }
-}
-
 // Describes a single interactive item within the menu bar.
 public struct MenuItem : Equatable {
   public var title          : String
-  public var activationKey  : MenuActivationKey
+  public var activationKey  : TerminalInput.Token
   public var alignment      : MenuItemAlignment
   public var isHighlighted  : Bool
 
-  public init ( title: String, activationKey: MenuActivationKey, alignment: MenuItemAlignment = .leading, isHighlighted: Bool = false ) {
+  public init ( title: String, activationKey: TerminalInput.Token, alignment: MenuItemAlignment = .leading, isHighlighted: Bool = false ) {
     self.title         = title
     self.activationKey = activationKey
     self.alignment     = alignment
@@ -37,7 +21,7 @@ public struct MenuItem : Equatable {
   }
 
   public func matches ( token: TerminalInput.Token ) -> Bool {
-    return activationKey.matches(token: token)
+    return activationKey == token
   }
 }
 

--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -36,12 +36,12 @@ final class DemoApplication {
     menuBar = MenuBar(
       items            : [
         MenuItem ( title: "File",
-                   activationKey: MenuActivationKey(token: .meta(.alt("f"))),
+                   activationKey: .meta(.alt("f")),
                    alignment    : .leading,
                    isHighlighted: true
         ),
         MenuItem ( title: "Help",
-                   activationKey: MenuActivationKey(token: .meta(.alt("h"))),
+                   activationKey: .meta(.alt("h")),
                    alignment: .trailing
       )
       ],

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -49,7 +49,7 @@ final class CodexTUITests: XCTestCase {
   }
 
   func testMenuItemMatchesPrintableAccelerator () {
-    let accelerator  = MenuActivationKey(token: .meta(.alt("f")))
+    let accelerator  = TerminalInput.Token.meta(.alt("f"))
     let item         = MenuItem(title: "File", activationKey: accelerator)
 
     let metaMatching = TerminalInput.Token.meta(.alt("f"))


### PR DESCRIPTION
## Summary
- have MenuItem accept TerminalInput.Token directly and drop the redundant MenuActivationKey wrapper
- update demo, docs, and tests to use the streamlined API

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e4e8777d248328b209ea8fa1ef775a