### PR TITLE
Stop ignoring SIGWINCH in SignalObserver

### DIFF
--- a/Sources/CodexTUI/Platform/SignalHandling.swift
+++ b/Sources/CodexTUI/Platform/SignalHandling.swift
@@ -29,8 +29,6 @@ public final class SignalObserver {
   public func start () {
     guard source == nil else { return }
 
-    signal(monitoredSignal, SIG_IGN)
-
     let source = DispatchSource.makeSignalSource(signal: monitoredSignal, queue: queue)
     source.setEventHandler { [weak self] in
       self?.handler?()
@@ -38,7 +36,6 @@ public final class SignalObserver {
     source.resume()
 
     self.source = source
-    signal(monitoredSignal, SIG_IGN)
   }
 
   // Cancels the dispatch source and releases the handler closure.


### PR DESCRIPTION
## Summary
- remove the calls that set SIGWINCH to SIG_IGN so the signal is delivered on every platform

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e4ef9bb47c832892ff0df192b718a7