### PR TITLE
Use dedicated queues for signal observer dispatch

### DIFF
--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -94,7 +94,7 @@ final class CodexTUITests: XCTestCase {
       input          : input,
       terminalMode   : mode,
       configuration  : configuration,
-      signalObserver : SignalObserver(queue: DispatchQueue(label: "test-signal-queue"))
+      signalObserver : SignalObserver(signalQueue: DispatchQueue(label: "test-signal-queue"))
     )
 
     let expectation = expectation(description: "Key event delivered without buffering")


### PR DESCRIPTION
## Summary
- use a dedicated background queue for `SignalObserver` dispatch sources
- dispatch signal handlers on a configurable handler queue that defaults to the main queue
- update tests to use the revised initializer signature

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e4f632499c832890b4819c0414ed26