### PR TITLE
Ensure surfaces clear with theme defaults

### DIFF
--- a/Sources/CodexTUI/Rendering/Surface.swift
+++ b/Sources/CodexTUI/Rendering/Surface.swift
@@ -137,7 +137,7 @@ public enum SurfaceRenderer {
 
       sequences.append(AnsiSequence(rawValue: String(change.tile.character)))
 
-      if change.tile.attributes.style.requiresReset {
+      if change.tile.attributes != ColorPair() && change.tile.attributes.style.requiresReset {
         sequences.append(TerminalOutput.TextStyle.resetSequence())
       }
     }

--- a/Sources/CodexTUI/Scenes/Scene.swift
+++ b/Sources/CodexTUI/Scenes/Scene.swift
@@ -47,7 +47,11 @@ public final class Scene {
       width  : bounds.width,
       height : bounds.height
     )
-    surface.clear()
+
+    let defaultAttributes = configuration.theme.contentDefault
+    let defaultTile       = SurfaceTile(character: " ", attributes: defaultAttributes)
+
+    surface.clear(with: defaultTile)
 
     let context     = layoutContext(for: bounds)
     let rootLayout  = rootWidget.layout(in: context)


### PR DESCRIPTION
## Summary
- clear the surface with the scene theme's default content tile before rendering
- skip emitting reset sequences for empty color pairs while preserving style-required resets

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68e526325de08328aefb38d87461a6a1