### PR TITLE
Adjust trailing menu and status bar layout

### DIFF
--- a/Sources/CodexTUI/Components/MenuBar.swift
+++ b/Sources/CodexTUI/Components/MenuBar.swift
@@ -44,7 +44,7 @@ public struct MenuBar : Widget {
     var commands = [RenderCommand]()
 
     var leftColumn  = context.bounds.column
-    var rightColumn = context.bounds.maxCol
+    var rightColumn = context.bounds.maxCol + 1
 
     // Leading entries are emitted left-to-right, adding a space between each title.
     for item in items where item.alignment == .leading {
@@ -54,9 +54,9 @@ public struct MenuBar : Widget {
 
     // Trailing entries are walked in reverse so the right edge is packed tightly without layout maths for preceding items.
     for item in items.reversed() where item.alignment == .trailing {
-      rightColumn -= item.title.count
-      commands.append(contentsOf: render(item: item, row: row, column: rightColumn))
-      rightColumn -= 2
+      let start = rightColumn - item.title.count
+      commands.append(contentsOf: render(item: item, row: row, column: start))
+      rightColumn = start - 2
     }
 
     return WidgetLayoutResult(bounds: BoxBounds(row: row, column: context.bounds.column, width: context.bounds.width, height: 1), commands: commands)

--- a/Sources/CodexTUI/Components/StatusBar.swift
+++ b/Sources/CodexTUI/Components/StatusBar.swift
@@ -31,7 +31,7 @@ public struct StatusBar : Widget {
     let row      = context.bounds.maxRow
 
     var leftColumn  = context.bounds.column
-    var rightColumn = context.bounds.maxCol
+    var rightColumn = context.bounds.maxCol + 1
 
     // Leading items push characters from the left edge.
     for item in items where item.alignment == .leading {
@@ -41,9 +41,9 @@ public struct StatusBar : Widget {
 
     // Trailing items render in reverse order to avoid overlapping as we walk from right to left.
     for item in items.reversed() where item.alignment == .trailing {
-      rightColumn -= item.text.count
-      commands.append(contentsOf: render(item: item, row: row, column: rightColumn))
-      rightColumn -= 1
+      let start = rightColumn - item.text.count
+      commands.append(contentsOf: render(item: item, row: row, column: start))
+      rightColumn = start - 1
     }
 
     return WidgetLayoutResult(bounds: BoxBounds(row: row, column: context.bounds.column, width: context.bounds.width, height: 1), commands: commands)


### PR DESCRIPTION
## Summary
- adjust trailing menu bar layout to anchor items to the right edge while keeping existing spacing
- apply the same right-edge anchoring logic to the status bar with its single-space padding

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_e_68e52c9600c08328bd09c7d61b7f9d0a