### PR TITLE
Fill menu and status bars with base style

### DIFF
--- a/Sources/CodexTUI/Components/MenuBar.swift
+++ b/Sources/CodexTUI/Components/MenuBar.swift
@@ -40,11 +40,27 @@ public struct MenuBar : Widget {
   }
 
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
-    let row = context.bounds.row
-    var commands = [RenderCommand]()
+    let row          = context.bounds.row
+    let startColumn  = context.bounds.column
+    let endColumn    = context.bounds.maxCol
+    var commands     = [RenderCommand]()
+    var leftColumn   = startColumn
+    var rightColumn  = context.bounds.maxCol + 1
 
-    var leftColumn  = context.bounds.column
-    var rightColumn = context.bounds.maxCol + 1
+    if startColumn <= endColumn {
+      for column in startColumn...endColumn {
+        commands.append(
+          RenderCommand(
+            row   : row,
+            column: column,
+            tile  : SurfaceTile(
+              character : " ",
+              attributes: style
+            )
+          )
+        )
+      }
+    }
 
     // Leading entries are emitted left-to-right, adding a space between each title.
     for item in items where item.alignment == .leading {

--- a/Sources/CodexTUI/Components/StatusBar.swift
+++ b/Sources/CodexTUI/Components/StatusBar.swift
@@ -27,11 +27,27 @@ public struct StatusBar : Widget {
   }
 
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
-    var commands = [RenderCommand]()
-    let row      = context.bounds.maxRow
+    let row          = context.bounds.maxRow
+    let startColumn  = context.bounds.column
+    let endColumn    = context.bounds.maxCol
+    var commands     = [RenderCommand]()
+    var leftColumn   = startColumn
+    var rightColumn  = context.bounds.maxCol + 1
 
-    var leftColumn  = context.bounds.column
-    var rightColumn = context.bounds.maxCol + 1
+    if startColumn <= endColumn {
+      for column in startColumn...endColumn {
+        commands.append(
+          RenderCommand(
+            row   : row,
+            column: column,
+            tile  : SurfaceTile(
+              character : " ",
+              attributes: style
+            )
+          )
+        )
+      }
+    }
 
     // Leading items push characters from the left edge.
     for item in items where item.alignment == .leading {


### PR DESCRIPTION
## Summary
- prefill the menu bar row with styled spaces so the background spans the full width
- apply the same full-width background fill to the status bar before rendering items

## Testing
- swift build --product CodexTUIDemo
- swift run CodexTUIDemo *(fails in container: terminal session crashes when entering raw mode)*

------
https://chatgpt.com/codex/tasks/task_e_68e52eb80d4083289ac34750a14dd2ce