### PR TITLE
Add menu controller and dropdown submenus

### DIFF
--- a/Sources/CodexTUI/Components/DropDownMenu.swift
+++ b/Sources/CodexTUI/Components/DropDownMenu.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+// Renders a boxed list of menu entries and highlights the focused row.
+public struct DropDownMenu : Widget {
+  public var entries        : [MenuItem.Entry]
+  public var selectionIndex : Int
+  public var style          : ColorPair
+  public var highlightStyle : ColorPair
+  public var borderStyle    : ColorPair
+
+  public init ( entries: [MenuItem.Entry], selectionIndex: Int = 0, style: ColorPair, highlightStyle: ColorPair, borderStyle: ColorPair ) {
+    self.entries        = entries
+    self.selectionIndex = selectionIndex
+    self.style          = style
+    self.highlightStyle = highlightStyle
+    self.borderStyle    = borderStyle
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    let bounds          = context.bounds
+    let box             = Box(bounds: bounds, style: borderStyle)
+    let boxLayout       = box.layout(in: context)
+    var commands        = [RenderCommand]()
+    var children        = [WidgetLayoutResult]()
+    children.append(boxLayout)
+
+    let interiorWidth   = max(0, bounds.width - 2)
+    let interiorHeight  = max(0, bounds.height - 2)
+    guard interiorWidth > 0 && interiorHeight > 0 else {
+      return WidgetLayoutResult(bounds: bounds, commands: commands, children: children)
+    }
+
+    let interiorRow     = bounds.row + 1
+    let interiorColumn  = bounds.column + 1
+    let maxIndex        = max(0, entries.count - 1)
+    let selectedIndex   = entries.isEmpty ? nil : max(0, min(selectionIndex, maxIndex))
+
+    for (index, entry) in entries.enumerated() {
+      guard index < interiorHeight else { break }
+      let row         = interiorRow + index
+      let attributes  = (index == selectedIndex) ? highlightStyle : style
+      let maxColumn   = interiorColumn + interiorWidth - 1
+
+      for column in interiorColumn...maxColumn {
+        commands.append(
+          RenderCommand(
+            row   : row,
+            column: column,
+            tile  : SurfaceTile(
+              character : " ",
+              attributes: attributes
+            )
+          )
+        )
+      }
+
+      var textColumn = interiorColumn
+      for character in entry.title {
+        guard textColumn <= maxColumn else { break }
+        commands.append(
+          RenderCommand(
+            row   : row,
+            column: textColumn,
+            tile  : SurfaceTile(
+              character : character,
+              attributes: attributes
+            )
+          )
+        )
+        textColumn += 1
+      }
+
+      if let hint = entry.acceleratorHint, hint.isEmpty == false {
+        let usableHint = hint.suffix(interiorWidth)
+        let hintWidth  = usableHint.count
+        let start      = max(interiorColumn, maxColumn - hintWidth + 1)
+        for (offset, character) in usableHint.enumerated() {
+          let column = start + offset
+          guard column >= interiorColumn && column <= maxColumn else { continue }
+          commands.append(
+            RenderCommand(
+              row   : row,
+              column: column,
+              tile  : SurfaceTile(
+                character : character,
+                attributes: attributes
+              )
+            )
+          )
+        }
+      }
+    }
+
+    return WidgetLayoutResult(bounds: bounds, commands: commands, children: children)
+  }
+}
+
+public extension DropDownMenu {
+  static func preferredSize ( for entries: [MenuItem.Entry] ) -> (width: Int, height: Int) {
+    let maxTitle = entries.map { $0.title.count }.max() ?? 0
+    let maxHint  = entries.map { $0.acceleratorHint?.count ?? 0 }.max() ?? 0
+    let hintGap  = maxHint > 0 && maxTitle > 0 ? 2 : (maxHint > 0 ? 1 : 0)
+    let content  = maxTitle + maxHint + hintGap
+    let width    = max(4, content + 2)
+    let height   = max(2, entries.count + 2)
+    return (width, height)
+  }
+
+  static func anchoredBounds ( for entries: [MenuItem.Entry], anchoredTo itemBounds: BoxBounds, in container: BoxBounds ) -> BoxBounds {
+    let size      = preferredSize(for: entries)
+    let width     = min(size.width, container.width)
+    let height    = min(size.height, container.height)
+    var row       = itemBounds.maxRow + 1
+    var column    = itemBounds.column
+
+    if row + height - 1 > container.maxRow {
+      row = itemBounds.row - height + 1
+    }
+
+    if row < container.row {
+      row = container.row
+    }
+
+    if column + width - 1 > container.maxCol {
+      column = container.maxCol - width + 1
+    }
+
+    if column < container.column {
+      column = container.column
+    }
+
+    return BoxBounds(row: row, column: column, width: width, height: height)
+  }
+}

--- a/Sources/CodexTUI/Runtime/MenuController.swift
+++ b/Sources/CodexTUI/Runtime/MenuController.swift
@@ -1,0 +1,249 @@
+import Foundation
+import TerminalInput
+
+// Coordinates menu state, overlays and keyboard routing for menu bars.
+public final class MenuController {
+  public private(set) var scene              : Scene
+  public private(set) var activeOverlayBounds: BoxBounds?
+
+  private var menuBarState      : MenuBar
+  private let contentWidget     : AnyWidget
+  private let statusBar         : StatusBar?
+  private var storedOverlays    : [AnyWidget]?
+  private var activeMenuIndex   : Int?
+  private var activeEntryIndex  : Int?
+  private var previousFocus     : FocusIdentifier?
+  private var viewportBounds    : BoxBounds
+
+  public init ( scene: Scene, menuBar: MenuBar, content: AnyWidget, statusBar: StatusBar? = nil, viewportBounds: BoxBounds = BoxBounds(row: 1, column: 1, width: 80, height: 24) ) {
+    self.scene             = scene
+    self.menuBarState      = menuBar
+    self.contentWidget     = content
+    self.statusBar         = statusBar
+    self.viewportBounds    = viewportBounds
+    self.storedOverlays    = nil
+    self.activeMenuIndex   = nil
+    self.activeEntryIndex  = nil
+    self.previousFocus     = nil
+    self.activeOverlayBounds = nil
+    refreshScene()
+  }
+
+  public var menuBar : MenuBar {
+    get { menuBarState }
+    set {
+      menuBarState = newValue
+      closeMenu()
+      refreshScene()
+    }
+  }
+
+  public var isMenuOpen : Bool {
+    return activeMenuIndex != nil
+  }
+
+  public func update ( viewportBounds: BoxBounds ) {
+    self.viewportBounds = viewportBounds
+    if isMenuOpen {
+      presentMenuOverlay()
+    }
+  }
+
+  public func handle ( token: TerminalInput.Token ) -> Bool {
+    if let index = menuBarState.items.firstIndex(where: { $0.matches(token: token) }) {
+      return openMenu(at: index)
+    }
+
+    guard let activeIndex = activeMenuIndex else { return false }
+
+    switch token {
+      case .escape :
+        closeMenu()
+        return true
+
+      case .cursor(let key) :
+        switch key {
+          case .down : return moveSelection(by: 1)
+          case .up   : return moveSelection(by: -1)
+          case .left : return moveMenuHorizontally(by: -1)
+          case .right: return moveMenuHorizontally(by: 1)
+          default    : return false
+        }
+
+      case .control(let key) :
+        switch key {
+          case .TAB    : return moveSelection(by: 1)
+          case .RETURN : return activateSelection()
+          default      : return false
+        }
+
+      case .meta :
+        // Allow alt key chords to switch menus while open.
+        if let index = menuBarState.items.firstIndex(where: { $0.matches(token: token) }) {
+          return openMenu(at: index)
+        }
+        return false
+
+      default :
+        break
+    }
+
+    // Tokens that reach this point should not be delivered to other widgets.
+    return activeIndex == activeMenuIndex
+  }
+
+  public func closeMenu () {
+    guard let _ = activeMenuIndex else { return }
+
+    activeMenuIndex      = nil
+    activeEntryIndex     = nil
+    activeOverlayBounds  = nil
+
+    if let baseOverlays = storedOverlays {
+      scene.overlays = baseOverlays
+    }
+
+    storedOverlays = nil
+
+    if let focus = previousFocus {
+      scene.focusChain.focus(identifier: focus)
+    }
+
+    previousFocus = nil
+    updateOpenFlags(activeIndex: nil)
+  }
+
+  private func openMenu ( at index: Int ) -> Bool {
+    guard menuBarState.items.indices.contains(index) else { return false }
+    let entries = menuBarState.items[index].entries
+    guard entries.isEmpty == false else { return false }
+
+    if activeMenuIndex == nil {
+      previousFocus  = scene.focusChain.active
+      storedOverlays = scene.overlays
+    }
+
+    let previousIndex = activeMenuIndex
+    activeMenuIndex   = index
+
+    if previousIndex != index {
+      activeEntryIndex = 0
+    } else {
+      let current = activeEntryIndex ?? 0
+      activeEntryIndex = max(0, min(current, entries.count - 1))
+    }
+
+    updateOpenFlags(activeIndex: index)
+    presentMenuOverlay()
+    return true
+  }
+
+  private func moveSelection ( by offset: Int ) -> Bool {
+    guard let menuIndex = activeMenuIndex else { return false }
+    let entries = menuBarState.items[menuIndex].entries
+    guard entries.isEmpty == false else { return false }
+
+    let count   = entries.count
+    let current = activeEntryIndex ?? 0
+    let next    = (current + offset + count) % count
+    activeEntryIndex = next
+    presentMenuOverlay()
+    return true
+  }
+
+  private func moveMenuHorizontally ( by offset: Int ) -> Bool {
+    guard menuBarState.items.isEmpty == false else { return false }
+    guard let currentIndex = activeMenuIndex else { return false }
+
+    var nextIndex = currentIndex
+    for _ in 0..<menuBarState.items.count {
+      nextIndex = (nextIndex + offset + menuBarState.items.count) % menuBarState.items.count
+      if menuBarState.items[nextIndex].entries.isEmpty == false {
+        return openMenu(at: nextIndex)
+      }
+    }
+
+    return false
+  }
+
+  private func activateSelection () -> Bool {
+    guard let menuIndex = activeMenuIndex else { return false }
+    guard let entryIndex = activeEntryIndex else { return false }
+    let entries = menuBarState.items[menuIndex].entries
+    guard entries.indices.contains(entryIndex) else { return false }
+
+    let action = entries[entryIndex].action
+    closeMenu()
+    action?()
+    return true
+  }
+
+  private func updateOpenFlags ( activeIndex: Int? ) {
+    for index in menuBarState.items.indices {
+      menuBarState.items[index].isOpen = (index == activeIndex)
+    }
+
+    refreshScene()
+  }
+
+  private func presentMenuOverlay () {
+    guard let menuIndex = activeMenuIndex else { return }
+    let entries = menuBarState.items[menuIndex].entries
+    guard entries.isEmpty == false else { return }
+
+    if storedOverlays == nil {
+      storedOverlays = scene.overlays
+    }
+
+    let itemBounds    = menuItemBounds(at: menuIndex)
+    let dropDownBounds = DropDownMenu.anchoredBounds(for: entries, anchoredTo: itemBounds, in: viewportBounds)
+    activeOverlayBounds = dropDownBounds
+
+    let dropDown = DropDownMenu(
+      entries        : entries,
+      selectionIndex : activeEntryIndex ?? 0,
+      style          : scene.configuration.theme.contentDefault,
+      highlightStyle : scene.configuration.theme.highlight,
+      borderStyle    : scene.configuration.theme.windowChrome
+    )
+
+    let overlay = Overlay(
+      bounds  : dropDownBounds,
+      content : AnyWidget(dropDown)
+    )
+
+    let base = storedOverlays ?? []
+    scene.overlays = base + [AnyWidget(overlay)]
+  }
+
+  private func menuItemBounds ( at index: Int ) -> BoxBounds {
+    let menuRowBounds = BoxBounds(row: viewportBounds.row, column: viewportBounds.column, width: viewportBounds.width, height: 1)
+    var leftColumn    = menuRowBounds.column
+    var rightColumn   = menuRowBounds.maxCol + 1
+
+    for (offset, item) in menuBarState.items.enumerated() where item.alignment == .leading {
+      let start = leftColumn
+      if offset == index {
+        return BoxBounds(row: menuRowBounds.row, column: start, width: item.title.count, height: 1)
+      }
+      leftColumn += item.title.count + 2
+    }
+
+    for element in menuBarState.items.enumerated().reversed() where element.element.alignment == .trailing {
+      let start = rightColumn - element.element.title.count
+      if element.offset == index {
+        return BoxBounds(row: menuRowBounds.row, column: start, width: element.element.title.count, height: 1)
+      }
+      rightColumn = start - 2
+    }
+
+    return BoxBounds(row: menuRowBounds.row, column: menuRowBounds.column, width: 0, height: 1)
+  }
+
+  private func refreshScene () {
+    let visibleMenu   = scene.configuration.showMenuBar ? menuBarState : nil
+    let visibleStatus = scene.configuration.showStatusBar ? statusBar : nil
+    let scaffold      = Scaffold(menuBar: visibleMenu, content: contentWidget, statusBar: visibleStatus)
+    scene.rootWidget  = AnyWidget(scaffold)
+  }
+}

--- a/Sources/CodexTUI/Runtime/TerminalDriver.swift
+++ b/Sources/CodexTUI/Runtime/TerminalDriver.swift
@@ -37,6 +37,11 @@ public final class TerminalDriver {
 
   public var onKeyEvent : ( (TerminalInput.Token) -> Void )?
   public var onResize   : ( (BoxBounds) -> Void )?
+  public var menuController : MenuController? {
+    didSet {
+      menuController?.update(viewportBounds: currentBounds)
+    }
+  }
 
   private let input           : TerminalInput
   private let terminal        : TerminalOutput.Terminal
@@ -129,6 +134,7 @@ public final class TerminalDriver {
   // Updates the backing surface when the terminal reports a new size and informs listeners.
   public func handleResize ( width: Int, height: Int ) {
     currentBounds = BoxBounds(row: 1, column: 1, width: width, height: height)
+    menuController?.update(viewportBounds: currentBounds)
     onResize?(currentBounds)
     redraw()
   }
@@ -191,6 +197,11 @@ public final class TerminalDriver {
   // Emits terminal tokens to the driver callbacks when active.
   private func route ( token: TerminalInput.Token ) {
     guard state == .running else { return }
+    if let controller = menuController, controller.handle(token: token) {
+      redraw()
+      return
+    }
+
     onKeyEvent?(token)
   }
 


### PR DESCRIPTION
## Summary
- add submenu metadata to menu items and render active highlight when open
- introduce a dropdown menu widget and menu controller to manage overlays and focus
- route keyboard input through the controller, update the demo, and add menu interaction tests

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e532d2534c83289f3428910928a041