### PR TITLE
Support configurable text entry start width

### DIFF
--- a/Sources/CodexTUI/Components/TextEntryBox.swift
+++ b/Sources/CodexTUI/Components/TextEntryBox.swift
@@ -148,9 +148,9 @@ public struct TextEntryBox : Widget {
 }
 
 public extension TextEntryBox {
-  static func preferredSize ( title: String, prompt: String?, text: String, buttons: [TextEntryBoxButton] ) -> (width: Int, height: Int) {
+  static func preferredSize ( title: String, prompt: String?, text: String, buttons: [TextEntryBoxButton], minimumFieldWidth: Int = 1 ) -> (width: Int, height: Int) {
     let promptWidth   = prompt.map { $0.count } ?? 0
-    let fieldWidth    = max(1, text.count + 1)
+    let fieldWidth    = max(minimumFieldWidth, text.count + 1)
     let contentWidths = [title.count, promptWidth, fieldWidth]
     let maxContent    = contentWidths.max() ?? 0
 
@@ -165,9 +165,9 @@ public extension TextEntryBox {
     )
   }
 
-  static func centeredBounds ( title: String, prompt: String?, text: String, buttons: [TextEntryBoxButton], in container: BoxBounds ) -> BoxBounds {
+  static func centeredBounds ( title: String, prompt: String?, text: String, buttons: [TextEntryBoxButton], minimumFieldWidth: Int = 1, in container: BoxBounds ) -> BoxBounds {
     let promptWidth   = prompt.map { $0.count } ?? 0
-    let fieldWidth    = max(1, text.count + 1)
+    let fieldWidth    = max(minimumFieldWidth, text.count + 1)
     let contentWidths = [title.count, promptWidth, fieldWidth]
     let maxContent    = contentWidths.max() ?? 0
 

--- a/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
+++ b/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
@@ -21,11 +21,13 @@ public final class TextEntryBoxController {
   private var storedOverlays : [AnyWidget]?
   private var previousFocus  : FocusIdentifier?
   private var viewportBounds : BoxBounds
+  private var startWidth     : Int
   private var state          : State?
 
-  public init ( scene: Scene, viewportBounds: BoxBounds = BoxBounds(row: 1, column: 1, width: 80, height: 24) ) {
+  public init ( scene: Scene, viewportBounds: BoxBounds = BoxBounds(row: 1, column: 1, width: 80, height: 24), startWidth: Int? = nil ) {
     self.scene          = scene
     self.viewportBounds = viewportBounds
+    self.startWidth     = max(1, startWidth ?? 1)
     self.storedOverlays = nil
     self.previousFocus  = nil
     self.state          = nil
@@ -163,7 +165,7 @@ public final class TextEntryBoxController {
 
     state.caret = max(0, min(state.caret, state.text.count))
 
-    let bounds = TextEntryBox.centeredBounds(title: state.title, prompt: state.prompt, text: state.text, buttons: state.buttons, in: viewportBounds)
+    let bounds = TextEntryBox.centeredBounds(title: state.title, prompt: state.prompt, text: state.text, buttons: state.buttons, minimumFieldWidth: startWidth, in: viewportBounds)
     let theme  = scene.configuration.theme
     let widget = TextEntryBox(
       title             : state.title,

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -321,6 +321,34 @@ final class CodexTUITests: XCTestCase {
     XCTAssertEqual(scene.focusChain.active, initialFocus)
   }
 
+  func testTextEntryBoxControllerRespectsStartWidth () {
+    let theme      = Theme.codex
+    let buffer     = TextBuffer(identifier: FocusIdentifier("log"), isInteractive: true)
+    let focusChain = FocusChain()
+    focusChain.register(node: buffer.focusNode())
+    let scene      = Scene.standard(content: AnyWidget(buffer), configuration: SceneConfiguration(theme: theme), focusChain: focusChain)
+    let viewport   = BoxBounds(row: 1, column: 1, width: 60, height: 18)
+    let startWidth = 20
+    let controller = TextEntryBoxController(scene: scene, viewportBounds: viewport, startWidth: startWidth)
+    let buttons    = [
+      TextEntryBoxButton(text: "Save"),
+      TextEntryBoxButton(text: "Cancel")
+    ]
+
+    controller.present(title: "Input", prompt: "Name", text: "", buttons: buttons)
+
+    XCTAssertTrue(controller.isPresenting)
+
+    guard let bounds = controller.currentBounds else {
+      XCTFail("Expected bounds to be set")
+      return
+    }
+
+    let expected = TextEntryBox.centeredBounds(title: "Input", prompt: "Name", text: "", buttons: buttons, minimumFieldWidth: startWidth, in: viewport)
+
+    XCTAssertEqual(bounds.width, expected.width)
+  }
+
   func testMenuControllerOpensMenuAndProducesOverlay () {
     let theme      = Theme.codex
     let entries    = [


### PR DESCRIPTION
## Summary
- add a configurable starting width to TextEntryBoxController and forward it to layout calculations
- extend TextEntryBox sizing helpers to support a minimum field width clamp
- cover the controller width behaviour with a new unit test

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e54f3f9998832887891709007bf293