### PR TITLE
Handle DEL control key in text entry controller

### DIFF
--- a/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
+++ b/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
@@ -101,7 +101,7 @@ public final class TextEntryBoxController {
             activateButton(at: state.activeIndex)
             return true
 
-          case .BACKSPACE :
+          case .BACKSPACE, .DEL :
             if state.caret > 0 {
               let removalIndex = state.text.index(state.text.startIndex, offsetBy: state.caret)
               let lowerBound   = state.text.index(before: removalIndex)

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -301,6 +301,10 @@ final class CodexTUITests: XCTestCase {
     XCTAssertTrue(controller.handle(token: .cursor(.right)))
     XCTAssertEqual(controller.caretIndex, 1)
 
+    XCTAssertTrue(controller.handle(token: .control(.DEL)))
+    XCTAssertEqual(controller.currentText, "")
+    XCTAssertEqual(controller.caretIndex, 0)
+
     XCTAssertTrue(controller.handle(token: .control(.TAB)))
     XCTAssertEqual(controller.activeButton, 1)
 
@@ -308,7 +312,7 @@ final class CodexTUITests: XCTestCase {
     XCTAssertEqual(controller.activeButton, 0)
 
     XCTAssertTrue(controller.handle(token: .control(.RETURN)))
-    XCTAssertEqual(capturedText, "b")
+    XCTAssertEqual(capturedText, "")
     XCTAssertFalse(controller.isPresenting)
     XCTAssertEqual(scene.overlays.count, initialOverlays.count)
     XCTAssertEqual(scene.focusChain.active, initialFocus)


### PR DESCRIPTION
## Summary
- treat the DEL control key like BACKSPACE in the text entry controller so characters can be removed
- extend the text entry controller test to cover DEL handling and updated expectations

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e552c33bf08328bf8f0606efa22b04