### PR TITLE
Add explicit title styling for modal dialogs

### DIFF
--- a/Sources/CodexTUI/Components/MessageBox.swift
+++ b/Sources/CodexTUI/Components/MessageBox.swift
@@ -19,6 +19,7 @@ public struct MessageBox : Widget {
   public var messageLines      : [String]
   public var buttons           : [MessageBoxButton]
   public var activeButtonIndex : Int
+  public var titleStyle        : ColorPair
   public var contentStyle      : ColorPair
   public var buttonStyle       : ColorPair
   public var highlightStyle    : ColorPair
@@ -29,6 +30,7 @@ public struct MessageBox : Widget {
     messageLines: [String],
     buttons: [MessageBoxButton],
     activeButtonIndex: Int = 0,
+    titleStyle: ColorPair,
     contentStyle: ColorPair,
     buttonStyle: ColorPair,
     highlightStyle: ColorPair,
@@ -38,6 +40,7 @@ public struct MessageBox : Widget {
     self.messageLines      = messageLines
     self.buttons           = buttons
     self.activeButtonIndex = activeButtonIndex
+    self.titleStyle        = titleStyle
     self.contentStyle      = contentStyle
     self.buttonStyle       = buttonStyle
     self.highlightStyle    = highlightStyle
@@ -66,7 +69,7 @@ public struct MessageBox : Widget {
     var currentRow = interior.row
 
     if title.isEmpty == false {
-      renderCentered(text: title, row: currentRow, bounds: interior, style: highlightStyle, commands: &commands)
+      renderCentered(text: title, row: currentRow, bounds: interior, style: titleStyle, commands: &commands)
       currentRow = min(currentRow + 1, interior.maxRow)
     }
 

--- a/Sources/CodexTUI/Components/TextEntryBox.swift
+++ b/Sources/CodexTUI/Components/TextEntryBox.swift
@@ -20,6 +20,7 @@ public struct TextEntryBox : Widget {
   public var caretIndex        : Int
   public var buttons           : [TextEntryBoxButton]
   public var activeButtonIndex : Int
+  public var titleStyle        : ColorPair
   public var contentStyle      : ColorPair
   public var fieldStyle        : ColorPair
   public var caretStyle        : ColorPair
@@ -34,6 +35,7 @@ public struct TextEntryBox : Widget {
     caretIndex: Int,
     buttons: [TextEntryBoxButton],
     activeButtonIndex: Int = 0,
+    titleStyle: ColorPair,
     contentStyle: ColorPair,
     fieldStyle: ColorPair,
     caretStyle: ColorPair,
@@ -47,6 +49,7 @@ public struct TextEntryBox : Widget {
     self.caretIndex        = caretIndex
     self.buttons           = buttons
     self.activeButtonIndex = activeButtonIndex
+    self.titleStyle        = titleStyle
     self.contentStyle      = contentStyle
     self.fieldStyle        = fieldStyle
     self.caretStyle        = caretStyle
@@ -77,7 +80,7 @@ public struct TextEntryBox : Widget {
     var currentRow = interior.row
 
     if title.isEmpty == false {
-      renderCentered(text: title, row: currentRow, bounds: interior, style: highlightStyle, commands: &commands)
+      renderCentered(text: title, row: currentRow, bounds: interior, style: titleStyle, commands: &commands)
       currentRow = min(currentRow + 1, interior.maxRow)
     }
 

--- a/Sources/CodexTUI/Runtime/MessageBoxController.swift
+++ b/Sources/CodexTUI/Runtime/MessageBoxController.swift
@@ -129,13 +129,16 @@ public final class MessageBoxController {
       state.activeIndex = max(0, min(state.activeIndex, maxIndex))
     }
 
-    let bounds = MessageBox.centeredBounds(title: state.title, messageLines: state.messageLines, buttons: state.buttons, in: viewportBounds)
-    let theme  = scene.configuration.theme
+    let bounds     = MessageBox.centeredBounds(title: state.title, messageLines: state.messageLines, buttons: state.buttons, in: viewportBounds)
+    let theme      = scene.configuration.theme
+    var titleStyle = theme.contentDefault
+    titleStyle.style.insert(.bold)
     let widget = MessageBox(
       title             : state.title,
       messageLines      : state.messageLines,
       buttons           : state.buttons,
       activeButtonIndex : state.activeIndex,
+      titleStyle        : titleStyle,
       contentStyle      : theme.contentDefault,
       buttonStyle       : theme.dimHighlight,
       highlightStyle    : theme.highlight,

--- a/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
+++ b/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
@@ -165,8 +165,10 @@ public final class TextEntryBoxController {
 
     state.caret = max(0, min(state.caret, state.text.count))
 
-    let bounds = TextEntryBox.centeredBounds(title: state.title, prompt: state.prompt, text: state.text, buttons: state.buttons, minimumFieldWidth: startWidth, in: viewportBounds)
-    let theme  = scene.configuration.theme
+    let bounds     = TextEntryBox.centeredBounds(title: state.title, prompt: state.prompt, text: state.text, buttons: state.buttons, minimumFieldWidth: startWidth, in: viewportBounds)
+    let theme      = scene.configuration.theme
+    var titleStyle = theme.contentDefault
+    titleStyle.style.insert(.bold)
     let widget = TextEntryBox(
       title             : state.title,
       prompt            : state.prompt,
@@ -174,6 +176,7 @@ public final class TextEntryBoxController {
       caretIndex        : state.caret,
       buttons           : state.buttons,
       activeButtonIndex : state.activeIndex,
+      titleStyle        : titleStyle,
       contentStyle      : theme.contentDefault,
       fieldStyle        : theme.contentDefault,
       caretStyle        : theme.highlight,

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -132,6 +132,7 @@ final class CodexTUITests: XCTestCase {
       messageLines      : ["Body"],
       buttons           : buttons,
       activeButtonIndex : 1,
+      titleStyle        : theme.highlight,
       contentStyle      : theme.contentDefault,
       buttonStyle       : theme.dimHighlight,
       highlightStyle    : theme.highlight,
@@ -190,6 +191,7 @@ final class CodexTUITests: XCTestCase {
       caretIndex        : 1,
       buttons           : buttons,
       activeButtonIndex : 0,
+      titleStyle        : theme.highlight,
       contentStyle      : theme.contentDefault,
       fieldStyle        : theme.contentDefault,
       caretStyle        : theme.highlight,
@@ -247,6 +249,29 @@ final class CodexTUITests: XCTestCase {
     XCTAssertEqual(controller.activeButton, 0)
     XCTAssertEqual(scene.overlays.count, initialOverlays.count + 1)
 
+    var expectedTitleStyle = theme.contentDefault
+    expectedTitleStyle.style.insert(.bold)
+
+    guard let bounds = controller.currentBounds else {
+      XCTFail("Expected message box bounds to be available")
+      return
+    }
+
+    let context        = scene.layoutContext(for: viewport)
+    let overlayLayout  = scene.overlays.last!.layout(in: context)
+    let overlayCommands = overlayLayout.flattenedCommands()
+    let interior       = bounds.inset(by: EdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1))
+    let titleRow       = interior.row
+    let titleCommands  = overlayCommands.filter { command in
+      return command.row == titleRow && command.column >= interior.column && command.column <= interior.maxCol
+    }
+
+    let messageTitleCommands = titleCommands.filter { $0.tile.attributes == expectedTitleStyle }.sorted { $0.column < $1.column }
+
+    XCTAssertFalse(messageTitleCommands.isEmpty)
+    let renderedMessageTitle = String(messageTitleCommands.map { $0.tile.character })
+    XCTAssertEqual(renderedMessageTitle, "Notice")
+
     XCTAssertTrue(controller.handle(token: .control(.TAB)))
     XCTAssertEqual(controller.activeButton, 1)
 
@@ -286,6 +311,29 @@ final class CodexTUITests: XCTestCase {
     XCTAssertTrue(controller.isPresenting)
     XCTAssertEqual(controller.currentText, "")
     XCTAssertEqual(controller.caretIndex, 0)
+
+    var expectedTitleStyle = theme.contentDefault
+    expectedTitleStyle.style.insert(.bold)
+
+    guard let bounds = controller.currentBounds else {
+      XCTFail("Expected text entry box bounds to be available")
+      return
+    }
+
+    let context        = scene.layoutContext(for: viewport)
+    let overlayLayout  = scene.overlays.last!.layout(in: context)
+    let overlayCommands = overlayLayout.flattenedCommands()
+    let interior       = bounds.inset(by: EdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1))
+    let titleRow       = interior.row
+    let titleCommands  = overlayCommands.filter { command in
+      return command.row == titleRow && command.column >= interior.column && command.column <= interior.maxCol
+    }
+
+    let entryTitleCommands = titleCommands.filter { $0.tile.attributes == expectedTitleStyle }.sorted { $0.column < $1.column }
+
+    XCTAssertFalse(entryTitleCommands.isEmpty)
+    let renderedEntryTitle = String(entryTitleCommands.map { $0.tile.character })
+    XCTAssertEqual(renderedEntryTitle, "Input")
 
     XCTAssertTrue(controller.handle(token: .text("ab")))
     XCTAssertEqual(controller.currentText, "ab")


### PR DESCRIPTION
## Summary
- add dedicated title styling to the message and text entry widgets
- brighten modal titles based on the theme when controllers present overlays
- extend unit tests to cover the new title style behaviour

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e5562052a88328b1ae95b9a745e45b