### PR TITLE
Allow overriding dialog button styles

### DIFF
--- a/Sources/CodexTUI/Runtime/MessageBoxController.swift
+++ b/Sources/CodexTUI/Runtime/MessageBoxController.swift
@@ -3,10 +3,11 @@ import TerminalInput
 
 public final class MessageBoxController {
   private struct State {
-    var title        : String
-    var messageLines : [String]
-    var buttons      : [MessageBoxButton]
-    var activeIndex  : Int
+    var title               : String
+    var messageLines        : [String]
+    var buttons             : [MessageBoxButton]
+    var activeIndex         : Int
+    var buttonStyleOverride : ColorPair?
   }
 
   public private(set) var scene           : Scene
@@ -30,7 +31,12 @@ public final class MessageBoxController {
     self.currentBounds  = nil
   }
 
-  public func present ( title: String, messageLines: [String], buttons: [MessageBoxButton] ) {
+  public func present (
+    title: String,
+    messageLines: [String],
+    buttons: [MessageBoxButton],
+    buttonStyleOverride: ColorPair? = nil
+  ) {
     guard buttons.isEmpty == false else { return }
 
     if storedOverlays == nil {
@@ -39,7 +45,13 @@ public final class MessageBoxController {
 
     previousFocus = scene.focusChain.active
 
-    let newState = State(title: title, messageLines: messageLines, buttons: buttons, activeIndex: 0)
+    let newState = State(
+      title             : title,
+      messageLines      : messageLines,
+      buttons           : buttons,
+      activeIndex       : 0,
+      buttonStyleOverride: buttonStyleOverride
+    )
     presentState(newState)
   }
 
@@ -129,9 +141,10 @@ public final class MessageBoxController {
       state.activeIndex = max(0, min(state.activeIndex, maxIndex))
     }
 
-    let bounds     = MessageBox.centeredBounds(title: state.title, messageLines: state.messageLines, buttons: state.buttons, in: viewportBounds)
-    let theme      = scene.configuration.theme
-    var titleStyle = theme.contentDefault
+    let bounds       = MessageBox.centeredBounds(title: state.title, messageLines: state.messageLines, buttons: state.buttons, in: viewportBounds)
+    let theme        = scene.configuration.theme
+    let buttonStyle  = state.buttonStyleOverride ?? theme.menuBar
+    var titleStyle   = theme.contentDefault
     titleStyle.style.insert(.bold)
     let widget = MessageBox(
       title             : state.title,
@@ -140,7 +153,7 @@ public final class MessageBoxController {
       activeButtonIndex : state.activeIndex,
       titleStyle        : titleStyle,
       contentStyle      : theme.contentDefault,
-      buttonStyle       : theme.dimHighlight,
+      buttonStyle       : buttonStyle,
       highlightStyle    : theme.highlight,
       borderStyle       : theme.windowChrome
     )
@@ -153,7 +166,13 @@ public final class MessageBoxController {
     scene.overlays = (storedOverlays ?? []) + [AnyWidget(overlay)]
     currentBounds  = bounds
     activeButton   = state.activeIndex
-    self.state     = State(title: state.title, messageLines: state.messageLines, buttons: state.buttons, activeIndex: state.activeIndex)
+    self.state     = State(
+      title             : state.title,
+      messageLines      : state.messageLines,
+      buttons           : state.buttons,
+      activeIndex       : state.activeIndex,
+      buttonStyleOverride: state.buttonStyleOverride
+    )
     isPresenting   = true
   }
 

--- a/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
+++ b/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
@@ -3,12 +3,13 @@ import TerminalInput
 
 public final class TextEntryBoxController {
   private struct State {
-    var title        : String
-    var prompt       : String?
-    var buttons      : [TextEntryBoxButton]
-    var activeIndex  : Int
-    var text         : String
-    var caret        : Int
+    var title               : String
+    var prompt              : String?
+    var buttons             : [TextEntryBoxButton]
+    var activeIndex         : Int
+    var text                : String
+    var caret               : Int
+    var buttonStyleOverride : ColorPair?
   }
 
   public private(set) var scene         : Scene
@@ -38,7 +39,13 @@ public final class TextEntryBoxController {
     self.caretIndex     = 0
   }
 
-  public func present ( title: String, prompt: String? = nil, text: String = "", buttons: [TextEntryBoxButton] ) {
+  public func present (
+    title: String,
+    prompt: String? = nil,
+    text: String = "",
+    buttons: [TextEntryBoxButton],
+    buttonStyleOverride: ColorPair? = nil
+  ) {
     guard buttons.isEmpty == false else { return }
 
     if storedOverlays == nil {
@@ -47,7 +54,15 @@ public final class TextEntryBoxController {
 
     previousFocus = scene.focusChain.active
 
-    let newState = State(title: title, prompt: prompt, buttons: buttons, activeIndex: 0, text: text, caret: text.count)
+    let newState = State(
+      title             : title,
+      prompt            : prompt,
+      buttons           : buttons,
+      activeIndex       : 0,
+      text              : text,
+      caret             : text.count,
+      buttonStyleOverride: buttonStyleOverride
+    )
     presentState(newState)
   }
 
@@ -165,9 +180,10 @@ public final class TextEntryBoxController {
 
     state.caret = max(0, min(state.caret, state.text.count))
 
-    let bounds     = TextEntryBox.centeredBounds(title: state.title, prompt: state.prompt, text: state.text, buttons: state.buttons, minimumFieldWidth: startWidth, in: viewportBounds)
-    let theme      = scene.configuration.theme
-    var titleStyle = theme.contentDefault
+    let bounds       = TextEntryBox.centeredBounds(title: state.title, prompt: state.prompt, text: state.text, buttons: state.buttons, minimumFieldWidth: startWidth, in: viewportBounds)
+    let theme        = scene.configuration.theme
+    let buttonStyle  = state.buttonStyleOverride ?? theme.menuBar
+    var titleStyle   = theme.contentDefault
     titleStyle.style.insert(.bold)
     let widget = TextEntryBox(
       title             : state.title,
@@ -180,7 +196,7 @@ public final class TextEntryBoxController {
       contentStyle      : theme.contentDefault,
       fieldStyle        : theme.contentDefault,
       caretStyle        : theme.highlight,
-      buttonStyle       : theme.dimHighlight,
+      buttonStyle       : buttonStyle,
       highlightStyle    : theme.highlight,
       borderStyle       : theme.windowChrome
     )
@@ -195,7 +211,15 @@ public final class TextEntryBoxController {
     activeButton   = state.activeIndex
     currentText    = state.text
     caretIndex     = state.caret
-    self.state     = State(title: state.title, prompt: state.prompt, buttons: state.buttons, activeIndex: state.activeIndex, text: state.text, caret: state.caret)
+    self.state     = State(
+      title             : state.title,
+      prompt            : state.prompt,
+      buttons           : state.buttons,
+      activeIndex       : state.activeIndex,
+      text              : state.text,
+      caret             : state.caret,
+      buttonStyleOverride: state.buttonStyleOverride
+    )
     isPresenting   = true
   }
 

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -289,6 +289,62 @@ final class CodexTUITests: XCTestCase {
     XCTAssertEqual(scene.focusChain.active, initialFocus)
   }
 
+  func testMessageBoxControllerDefaultsAndOverridesButtonStyle () {
+    let theme      = Theme.codex
+    let buffer     = TextBuffer(identifier: FocusIdentifier("log"), isInteractive: true)
+    let focusChain = FocusChain()
+    focusChain.register(node: buffer.focusNode())
+    let scene      = Scene.standard(content: AnyWidget(buffer), configuration: SceneConfiguration(theme: theme), focusChain: focusChain)
+    let viewport   = BoxBounds(row: 1, column: 1, width: 60, height: 18)
+    let controller = MessageBoxController(scene: scene, viewportBounds: viewport)
+    let buttons    = [
+      MessageBoxButton(text: "OK"),
+      MessageBoxButton(text: "Cancel")
+    ]
+
+    controller.present(title: "Notice", messageLines: ["Testing"], buttons: buttons)
+
+    guard let bounds = controller.currentBounds else {
+      XCTFail("Expected message box bounds to be available")
+      return
+    }
+
+    let context             = scene.layoutContext(for: viewport)
+    let overlayLayout       = scene.overlays.last!.layout(in: context)
+    let overlayCommands     = overlayLayout.flattenedCommands()
+    let interior            = bounds.inset(by: EdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1))
+    let buttonRow           = interior.maxRow
+    let buttonRowCommands   = overlayCommands.filter { $0.row == buttonRow }
+    let defaultStyleCommand = buttonRowCommands.first { $0.tile.attributes == theme.menuBar }
+    let highlightCommand    = buttonRowCommands.first { $0.tile.attributes == theme.highlight }
+
+    XCTAssertNotNil(defaultStyleCommand)
+    XCTAssertNotNil(highlightCommand)
+
+    controller.dismiss()
+
+    let overrideStyle = ColorPair(foreground: .red, background: .black)
+
+    controller.present(title: "Notice", messageLines: ["Testing"], buttons: buttons, buttonStyleOverride: overrideStyle)
+
+    guard let overrideBounds = controller.currentBounds else {
+      XCTFail("Expected message box bounds to be available")
+      return
+    }
+
+    let overrideContext         = scene.layoutContext(for: viewport)
+    let overrideLayout          = scene.overlays.last!.layout(in: overrideContext)
+    let overrideCommands        = overrideLayout.flattenedCommands()
+    let overrideInterior        = overrideBounds.inset(by: EdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1))
+    let overrideButtonRow       = overrideInterior.maxRow
+    let overrideButtonCommands  = overrideCommands.filter { $0.row == overrideButtonRow }
+    let overrideStyleCommand    = overrideButtonCommands.first { $0.tile.attributes == overrideStyle }
+    let overrideHighlight       = overrideButtonCommands.first { $0.tile.attributes == theme.highlight }
+
+    XCTAssertNotNil(overrideStyleCommand)
+    XCTAssertNotNil(overrideHighlight)
+  }
+
   func testTextEntryBoxControllerHandlesInputAndDismissal () {
     let theme      = Theme.codex
     let buffer     = TextBuffer(identifier: FocusIdentifier("log"), isInteractive: true)
@@ -371,6 +427,62 @@ final class CodexTUITests: XCTestCase {
     XCTAssertFalse(controller.isPresenting)
     XCTAssertEqual(scene.overlays.count, initialOverlays.count)
     XCTAssertEqual(scene.focusChain.active, initialFocus)
+  }
+
+  func testTextEntryBoxControllerDefaultsAndOverridesButtonStyle () {
+    let theme      = Theme.codex
+    let buffer     = TextBuffer(identifier: FocusIdentifier("log"), isInteractive: true)
+    let focusChain = FocusChain()
+    focusChain.register(node: buffer.focusNode())
+    let scene      = Scene.standard(content: AnyWidget(buffer), configuration: SceneConfiguration(theme: theme), focusChain: focusChain)
+    let viewport   = BoxBounds(row: 1, column: 1, width: 60, height: 18)
+    let controller = TextEntryBoxController(scene: scene, viewportBounds: viewport)
+    let buttons    = [
+      TextEntryBoxButton(text: "Save"),
+      TextEntryBoxButton(text: "Cancel")
+    ]
+
+    controller.present(title: "Input", prompt: "Name", text: "", buttons: buttons)
+
+    guard let bounds = controller.currentBounds else {
+      XCTFail("Expected text entry box bounds to be available")
+      return
+    }
+
+    let context             = scene.layoutContext(for: viewport)
+    let overlayLayout       = scene.overlays.last!.layout(in: context)
+    let overlayCommands     = overlayLayout.flattenedCommands()
+    let interior            = bounds.inset(by: EdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1))
+    let buttonRow           = interior.maxRow
+    let buttonRowCommands   = overlayCommands.filter { $0.row == buttonRow }
+    let defaultStyleCommand = buttonRowCommands.first { $0.tile.attributes == theme.menuBar }
+    let highlightCommand    = buttonRowCommands.first { $0.tile.attributes == theme.highlight }
+
+    XCTAssertNotNil(defaultStyleCommand)
+    XCTAssertNotNil(highlightCommand)
+
+    controller.dismiss()
+
+    let overrideStyle = ColorPair(foreground: .red, background: .black)
+
+    controller.present(title: "Input", prompt: "Name", text: "", buttons: buttons, buttonStyleOverride: overrideStyle)
+
+    guard let overrideBounds = controller.currentBounds else {
+      XCTFail("Expected text entry box bounds to be available")
+      return
+    }
+
+    let overrideContext         = scene.layoutContext(for: viewport)
+    let overrideLayout          = scene.overlays.last!.layout(in: overrideContext)
+    let overrideCommands        = overrideLayout.flattenedCommands()
+    let overrideInterior        = overrideBounds.inset(by: EdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1))
+    let overrideButtonRow       = overrideInterior.maxRow
+    let overrideButtonCommands  = overrideCommands.filter { $0.row == overrideButtonRow }
+    let overrideStyleCommand    = overrideButtonCommands.first { $0.tile.attributes == overrideStyle }
+    let overrideHighlight       = overrideButtonCommands.first { $0.tile.attributes == theme.highlight }
+
+    XCTAssertNotNil(overrideStyleCommand)
+    XCTAssertNotNil(overrideHighlight)
   }
 
   func testTextEntryBoxControllerRespectsStartWidth () {


### PR DESCRIPTION
## Summary
- allow message and text entry controllers to accept optional button style overrides
- fall back to the menu bar palette when no override is provided
- add tests covering both default and custom button style paths

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e558669c8c8328969f0c6fad6dbef4