### PR TITLE
Right align modal dialog buttons

### DIFF
--- a/Sources/CodexTUI/Components/ModalDialogSurface.swift
+++ b/Sources/CodexTUI/Components/ModalDialogSurface.swift
@@ -130,7 +130,7 @@ public enum ModalDialogSurface {
     }
 
     let totalWidth = buttonStrings.reduce(0) { $0 + $1.count } + max(0, buttonStrings.count - 1)
-    let offset     = max(0, (bounds.width - totalWidth) / 2)
+    let offset     = max(0, bounds.width - totalWidth)
     var column     = bounds.column + offset
     let maxIndex   = max(0, buttonStrings.count - 1)
     let highlight  = max(0, min(highlightIndex, maxIndex))

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -149,6 +149,13 @@ final class CodexTUITests: XCTestCase {
     }
 
     XCTAssertFalse(highlightTiles.isEmpty)
+
+    let interior      = bounds.inset(by: EdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1))
+    let edgeCommands  = commands.filter { command in
+      return command.row == buttonRow && command.column == interior.maxCol
+    }
+    XCTAssertFalse(edgeCommands.isEmpty)
+    XCTAssertEqual(edgeCommands.last?.tile.attributes, theme.highlight)
   }
 
   func testModalDialogSurfaceLayoutProvidesInteriorAndHighlight () {
@@ -176,6 +183,12 @@ final class CodexTUITests: XCTestCase {
     }
 
     XCTAssertFalse(highlightTiles.isEmpty)
+
+    let edgeCommands = layout.result.commands.filter { command in
+      return command.row == buttonRow && command.column == layout.interior.maxCol
+    }
+    XCTAssertFalse(edgeCommands.isEmpty)
+    XCTAssertEqual(edgeCommands.last?.tile.attributes, theme.highlight)
   }
 
   func testTextEntryBoxLayoutHighlightsCaret () {
@@ -224,6 +237,13 @@ final class CodexTUITests: XCTestCase {
         XCTAssertEqual(fallback.column, caretCol)
       }
     }
+
+    let buttonRow      = interior.maxRow
+    let edgeCommands   = commands.filter { command in
+      return command.row == buttonRow && command.column == interior.maxCol
+    }
+    XCTAssertFalse(edgeCommands.isEmpty)
+    XCTAssertEqual(edgeCommands.last?.tile.attributes, theme.dimHighlight)
   }
 
   func testMessageBoxControllerHandlesInputAndDismissal () {


### PR DESCRIPTION
## Summary
- align modal dialog button groups to the right edge of the dialog interior
- verify message box, modal dialog, and text entry layouts right-align their button rows

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e55dc91cc4832892841135f545a7ca