### PR TITLE
Add detailed documentation for types and layout functions

### DIFF
--- a/Sources/CodexTUI/CodexTUI.swift
+++ b/Sources/CodexTUI/CodexTUI.swift
@@ -2,10 +2,11 @@ import Foundation
 @_exported import TerminalInput
 @_exported import TerminalOutput
 
-// The public namespace that wraps convenience factories for bootstrapping a CodexTUI runtime.
+/// Public namespace that exposes convenience factories for bootstrapping a CodexTUI runtime.
 public enum CodexTUI {
-  // Creates a ready-to-run driver hooked up to the process STDIN/STDOUT and configured using sane defaults.
-  // The helper performs the low level TerminalInput/TerminalOutput wiring so the caller only needs to provide a Scene.
+  /// Creates a ready-to-run driver connected to the process STDIN/STDOUT and configured using sane
+  /// defaults. The helper performs the low-level TerminalInput/TerminalOutput wiring so the caller
+  /// only needs to provide a scene graph.
   public static func makeDriver ( scene: Scene, configuration: RuntimeConfiguration = RuntimeConfiguration() ) -> TerminalDriver {
     let connection = TerminalOutput.FileHandleTerminalConnection()
     let terminal   = TerminalOutput.Terminal(connection: connection)

--- a/Sources/CodexTUI/Components/Box.swift
+++ b/Sources/CodexTUI/Components/Box.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-// Draws a rectangular border using box drawing characters.
+/// Primitive widget that paints an ANSI box border. The type is used both directly by scenes and
+/// as a building block for higher-level surfaces such as modal dialogs or selection lists.
 public struct Box : Widget {
   public var bounds : BoxBounds
   public var style  : ColorPair
@@ -10,6 +11,12 @@ public struct Box : Widget {
     self.style   = style
   }
 
+  /// Produces the render commands required to trace the four edges of the box. The routine walks
+  /// horizontally first to fill the top and bottom edges, then vertically to cover the sides. Each
+  /// loop appends `RenderCommand` values describing the character and styling for a cell so the
+  /// renderer can correctly resolve junctions when multiple boxes overlap. Corner glyphs are added
+  /// explicitly at the end to ensure the final appearance is deterministic regardless of the helper
+  /// character decisions.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     var commands = [RenderCommand]()
 

--- a/Sources/CodexTUI/Components/DropDownMenu.swift
+++ b/Sources/CodexTUI/Components/DropDownMenu.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-// Renders a boxed list of menu entries and highlights the focused row.
+/// Widget that shows a menu item's submenu as a boxed list. It is effectively a specialised
+/// wrapper around `SelectionListSurface` that converts the menu entries into selection entries and
+/// exposes a simplified API tailored for menu interactions.
 public struct DropDownMenu : Widget {
   public var entries        : [MenuItem.Entry]
   public var selectionIndex : Int
@@ -16,6 +18,10 @@ public struct DropDownMenu : Widget {
     self.borderStyle    = borderStyle
   }
 
+  /// Delegates to `SelectionListSurface.layout` after converting the menu entries into the common
+  /// selection list representation. The resulting layout mirrors the behaviour of the standalone
+  /// selection list widget so the menu system benefits from the same scrolling, highlighting and
+  /// border logic without duplicating calculations.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let listEntries = entries.map { SelectionListEntry(menuEntry: $0) }
     let surface     = SelectionListSurface.layout(

--- a/Sources/CodexTUI/Components/MenuBar.swift
+++ b/Sources/CodexTUI/Components/MenuBar.swift
@@ -1,13 +1,18 @@
 import Foundation
 import TerminalInput
 
+/// Alignment strategy for positioning menu items inside the menu bar. Leading items flow from the
+/// left edge while trailing items are packed against the right edge.
 public enum MenuItemAlignment {
   case leading
   case trailing
 }
 
-// Describes a single interactive item within the menu bar.
+/// Describes a single interactive menu bar item, including its accelerator token, alignment and
+/// dropdown entries. The structure is intentionally value-based so scenes can easily diff and update
+/// menu state.
 public struct MenuItem : Equatable {
+  /// Represents a selectable entry inside a menu item's dropdown list.
   public struct Entry : Equatable {
     public var title           : String
     public var acceleratorHint : String?
@@ -54,7 +59,8 @@ public func == ( lhs: MenuItem, rhs: MenuItem ) -> Bool {
     lhs.entries == rhs.entries
 }
 
-// Renders a classic single line menu bar with highlighted accelerator characters.
+/// Widget that renders a single-line menu bar. It handles background clearing, accelerator
+/// highlighting and left/right alignment rules for menu items.
 public struct MenuBar : Widget {
   public var items            : [MenuItem]
   public var style            : ColorPair
@@ -68,6 +74,12 @@ public struct MenuBar : Widget {
     self.dimHighlightStyle = dimHighlightStyle
   }
 
+  /// Renders the menu bar within the supplied bounds. The routine first paints a solid background
+  /// across the entire row so gaps never appear between items. It then walks the leading items from
+  /// left to right updating a cursor as titles are written, and finally walks the trailing items in
+  /// reverse so they pack neatly against the right edge without requiring prior measurements. Each
+  /// item is rendered via `render(item:row:column:)`, which decides whether to use highlight colours
+  /// based on the item's state.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let row          = context.bounds.row
     let startColumn  = context.bounds.column

--- a/Sources/CodexTUI/Components/MessageBox.swift
+++ b/Sources/CodexTUI/Components/MessageBox.swift
@@ -1,6 +1,9 @@
 import Foundation
 import TerminalInput
 
+/// Model describing a button in the message box footer. Each button stores its display text,
+/// activation key and optional handler so the controller can perform the appropriate action when the
+/// user confirms the choice.
 public struct MessageBoxButton {
   public let text          : String
   public let activationKey : TerminalInput.ControlKey
@@ -13,7 +16,8 @@ public struct MessageBoxButton {
   }
 }
 
-// Renders a bordered message dialog with centred text and button row highlighting.
+/// Widget that renders a bordered message dialog with centred content and a highlighted button row.
+/// It is typically presented as a modal overlay to display alerts or confirmations.
 public struct MessageBox : Widget {
   public var title             : String
   public var messageLines      : [String]
@@ -50,6 +54,11 @@ public struct MessageBox : Widget {
     self.borderStyle       = borderStyle
   }
 
+  /// Lays out the dialog by delegating the structural work to `ModalDialogSurface`, which draws the
+  /// border, background and buttons. The routine then centres the title and message lines within the
+  /// returned interior bounds, inserting separators to visually distinguish the content from the
+  /// button row. Bounding calculations are clamped at every step so that even extremely small
+  /// viewports produce safe command lists.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let surface = ModalDialogSurface.layout(
       in               : context,

--- a/Sources/CodexTUI/Components/ModalDialogSurface.swift
+++ b/Sources/CodexTUI/Components/ModalDialogSurface.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Aggregates the results of laying out a modal dialog surface. It exposes the rendered border and
+/// button commands as well as the interior bounds and computed button row to downstream widgets.
 public struct ModalDialogSurfaceLayout {
   public var result    : WidgetLayoutResult
   public var interior  : BoxBounds
@@ -12,7 +14,15 @@ public struct ModalDialogSurfaceLayout {
   }
 }
 
+/// Namespace containing the shared rendering logic for modal dialog shells. Widgets such as
+/// `MessageBox` and `TextEntryBox` delegate to these helpers so they remain visually consistent.
 public enum ModalDialogSurface {
+  /// Lays out a modal dialog surface with an optional button row. The algorithm starts by invoking
+  /// the `Box` widget to draw the outer frame, captures its commands and derives the interior bounds
+  /// by insetting the box. When interior space exists it fills the background, then, if buttons are
+  /// present, it renders them along the bottom edge using either the default or highlight styling. The
+  /// function returns both the aggregated commands and metadata (interior bounds and button row) so
+  /// callers can continue layering content on top.
   public static func layout (
     in context        : LayoutContext,
     contentStyle      : ColorPair,

--- a/Sources/CodexTUI/Components/Overlay.swift
+++ b/Sources/CodexTUI/Components/Overlay.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-// Places a widget at explicit bounds irrespective of the parent layout tree.
+/// Widget that places its child at explicit bounds regardless of the parent layout flow. Scenes use
+/// it to present overlays such as modals or floating tooltips while reusing the existing widget
+/// infrastructure.
 public struct Overlay : Widget {
   public var content : AnyWidget
   public var bounds  : BoxBounds
@@ -10,6 +12,10 @@ public struct Overlay : Widget {
     self.content = content
   }
 
+  /// Forwards layout to the wrapped content using the overlay's fixed bounds. Because overlays live
+  /// in a separate coordinate space from their parent, we synthesise a new `LayoutContext` that
+  /// preserves the theme, focus snapshot and environment so the child renders consistently with the
+  /// rest of the scene.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let childContext = LayoutContext(bounds: bounds, theme: context.theme, focus: context.focus, environment: context.environment)
     let childLayout  = content.layout(in: childContext)

--- a/Sources/CodexTUI/Components/Scaffold.swift
+++ b/Sources/CodexTUI/Components/Scaffold.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-// Composes menu, content and status bar regions into a vertically stacked layout.
+/// Composite widget that arranges an optional menu bar, primary content region and optional status
+/// bar into a vertical stack. It provides the canonical scene layout used by the demo and runtime.
 public struct Scaffold : Widget {
   public var menuBar   : MenuBar?
   public var content   : AnyWidget
@@ -12,6 +13,10 @@ public struct Scaffold : Widget {
     self.statusBar = statusBar
   }
 
+  /// Splits the available bounds into up to three vertical slices. The routine reserves the first row
+  /// for the menu bar when present, the last row for the status bar, then assigns the remaining space
+  /// to the content widget. Each child receives its own `LayoutContext` so environment information such
+  /// as theme and focus snapshot flow naturally through the tree.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     var children = [WidgetLayoutResult]()
     let rootBounds = context.bounds

--- a/Sources/CodexTUI/Components/SelectionList.swift
+++ b/Sources/CodexTUI/Components/SelectionList.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// Composite widget that displays a titled selection list inside a bordered surface. It reuses the
+/// shared `SelectionListSurface` to render the scrollable body and adds optional title rendering on
+/// top of the calculated interior bounds.
 public struct SelectionList : Widget {
   public var title          : String
   public var entries        : [SelectionListEntry]
@@ -19,6 +22,11 @@ public struct SelectionList : Widget {
     self.borderStyle    = borderStyle
   }
 
+  /// Lays out the selection list by delegating the heavy lifting to `SelectionListSurface`. The
+  /// returned interior bounds are used to optionally render the header row, ensuring the title shares
+  /// the same padding and centring rules as the list content. Control flow mirrors the surface helper:
+  /// we quickly exit when there is no interior space and otherwise append the title commands before
+  /// returning the combined layout tree.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let headerRows = title.isEmpty ? 0 : 1
     let surface    = SelectionListSurface.layout(

--- a/Sources/CodexTUI/Components/SelectionListSurface.swift
+++ b/Sources/CodexTUI/Components/SelectionListSurface.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// Model representing a single selectable row displayed by the selection list surface. Entries
+/// capture the text, optional accelerator hint and an activation handler so callers can respond to
+/// user input without holding additional state.
 public struct SelectionListEntry {
   public var title           : String
   public var acceleratorHint : String?
@@ -12,6 +15,9 @@ public struct SelectionListEntry {
   }
 }
 
+/// Encapsulates the layout result produced by `SelectionListSurface`. The structure packages both
+/// the widget layout result and the calculated interior bounds that children such as headers may
+/// render into.
 public struct SelectionListSurfaceLayout {
   public var result   : WidgetLayoutResult
   public var interior : BoxBounds
@@ -22,7 +28,18 @@ public struct SelectionListSurfaceLayout {
   }
 }
 
+/// Shared rendering implementation used by selection lists and dropdown menus. It applies a box
+/// border, paints background fills for each row and emits commands for the item text and optional
+/// accelerator hints. The enum namespace keeps the helpers grouped without requiring instantiation.
 public enum SelectionListSurface {
+  /// Lays out the selection list within the supplied context. The routine first delegates to the
+  /// `Box` widget to draw the surrounding border, capturing its commands and any child layouts. It
+  /// then shrinks the interior by one character on each edge to account for the border thickness and
+  /// determines how many rows remain after optionally reserving header lines. For each visible entry
+  /// it fills the row with the appropriate background colour, writes the title characters until the
+  /// horizontal bound is reached and finally right-aligns accelerator hints by walking backwards from
+  /// the edge. The control flow is organised into short guarded sections so we can early-out when the
+  /// available area is exhausted, guaranteeing that downstream renderers never see negative geometry.
   public static func layout (
     entries        : [SelectionListEntry],
     selectionIndex : Int,
@@ -135,6 +152,9 @@ public enum SelectionListSurface {
     return SelectionListSurfaceLayout(result: result, interior: interior)
   }
 
+  /// Computes the preferred width and height for a list of entries when rendered within the
+  /// selection list surface. The calculation mirrors the layout routine by accounting for border
+  /// thickness and optional headers so callers can perform their own placement heuristics.
   public static func preferredSize (
     for entries   : [SelectionListEntry],
     preferredContentWidth : Int? = nil,
@@ -158,6 +178,11 @@ public enum SelectionListSurface {
     return maxTitle + maxHint + hintGap
   }
 
+  /// Determines bounds for a dropdown anchored to a menu item while keeping the menu within the
+  /// container. The function first clamps the preferred size to the container and then attempts to
+  /// position the list below the triggering item, flipping above when it would overflow the bottom
+  /// edge. Horizontal positioning keeps the left edge aligned unless the container would overflow,
+  /// in which case it slides the menu back into view.
   public static func anchoredBounds (
     for entries : [SelectionListEntry],
     anchoredTo itemBounds: BoxBounds,

--- a/Sources/CodexTUI/Components/StatusBar.swift
+++ b/Sources/CodexTUI/Components/StatusBar.swift
@@ -1,11 +1,13 @@
 import Foundation
 
+/// Alignment strategy controlling where a status bar item is rendered. Leading items expand from the
+/// left edge while trailing items pack tightly against the right edge.
 public enum StatusItemAlignment {
   case leading
   case trailing
 }
 
-// Simple descriptor used to render text segments inside the status bar.
+/// Describes a single textual segment in the status bar along with its alignment policy.
 public struct StatusItem : Equatable {
   public var text      : String
   public var alignment : StatusItemAlignment
@@ -16,7 +18,8 @@ public struct StatusItem : Equatable {
   }
 }
 
-// Renders a single line status bar with left/right aligned segments.
+/// Widget that renders a single-line status bar with left and right aligned segments. The
+/// implementation mirrors the menu bar so menus and status bars feel visually consistent.
 public struct StatusBar : Widget {
   public var items : [StatusItem]
   public var style : ColorPair
@@ -26,6 +29,10 @@ public struct StatusBar : Widget {
     self.style = style
   }
 
+  /// Renders the status bar along the bottom edge of the provided bounds. The function first clears
+  /// the row with the default style, then streams leading items from the left and trailing items from
+  /// the right, adjusting cursors as it goes. Processing the trailing items in reverse ensures their
+  /// text never overlaps despite not precomputing widths up front.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let row          = context.bounds.maxRow
     let startColumn  = context.bounds.column

--- a/Sources/CodexTUI/Components/Text.swift
+++ b/Sources/CodexTUI/Components/Text.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-// Minimal widget that renders an immutable string starting at a fixed origin.
+/// Minimal widget that renders an immutable string starting at a fixed origin. It is typically used
+/// for labels inside other composite widgets.
 public struct Text : Widget {
   public var content : String
   public var origin  : (row: Int, column: Int)
@@ -12,6 +13,9 @@ public struct Text : Widget {
     self.style    = style
   }
 
+  /// Emits a render command for each character in the string. The bounds are derived from the
+  /// configured origin and the string length so parent widgets can include the text when computing
+  /// their own sizes or hit testing logic.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let bounds = BoxBounds(row: origin.row, column: origin.column, width: content.count, height: 1)
     var commands = [RenderCommand]()

--- a/Sources/CodexTUI/Components/TextBuffer.swift
+++ b/Sources/CodexTUI/Components/TextBuffer.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-// Scrollable text view that can optionally participate in focus traversal.
+/// Scrollable text view that optionally participates in focus traversal. The buffer stores rendered
+/// lines and exposes a layout routine that clips and offsets the visible region to simulate scrolling
+/// without mutating the underlying content.
 public final class TextBuffer : FocusableWidget {
   public var focusIdentifier : FocusIdentifier
   public var lines           : [String]
@@ -28,7 +30,11 @@ public final class TextBuffer : FocusableWidget {
     scrollOffset  = max(0, lines.count - 1)
   }
 
-  // Projects the text buffer into the provided bounds respecting scroll offsets and clipping.
+  /// Renders the text buffer into the supplied bounds. The layout routine first applies any content
+  /// insets from the environment to determine the drawable interior, then clamps the scroll offset so
+  /// we never read past the buffer. It walks the visible slice of lines, emitting commands for each
+  /// character until the horizontal limit is reached, which mirrors how a terminal would clip output
+  /// in hardware.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let bounds    = context.bounds.inset(by: context.environment.contentInsets)
     let maxLines  = max(0, bounds.height)

--- a/Sources/CodexTUI/Components/TextEntryBox.swift
+++ b/Sources/CodexTUI/Components/TextEntryBox.swift
@@ -1,6 +1,8 @@
 import Foundation
 import TerminalInput
 
+/// Model representing an action button displayed below a text entry box. Buttons expose both their
+/// label and activation key so controllers can wire keyboard shortcuts to callbacks.
 public struct TextEntryBoxButton {
   public let text          : String
   public let activationKey : TerminalInput.ControlKey
@@ -13,6 +15,9 @@ public struct TextEntryBoxButton {
   }
 }
 
+/// Modal dialog style widget that combines a title, optional prompt, editable text field and action
+/// buttons. It builds on top of `ModalDialogSurface` to ensure consistent styling with other dialogs
+/// and adds caret rendering plus field centring logic.
 public struct TextEntryBox : Widget {
   public var title             : String
   public var prompt            : String?
@@ -61,6 +66,11 @@ public struct TextEntryBox : Widget {
     self.borderStyle       = borderStyle
   }
 
+  /// Lays out the text entry box by reusing `ModalDialogSurface` to draw the surrounding chrome and
+  /// button row. Once the surface returns interior bounds, the routine streams the title, prompt and
+  /// text field sequentially, inserting separators that mirror the dialog style. Calculations clamp
+  /// every intermediate rectangle to the available interior so the widget gracefully degrades in
+  /// cramped viewports.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let surface = ModalDialogSurface.layout(
       in               : context,

--- a/Sources/CodexTUI/Layout/BoxBounds.swift
+++ b/Sources/CodexTUI/Layout/BoxBounds.swift
@@ -1,12 +1,18 @@
 import Foundation
 
-// Describes a rectangular region within the terminal coordinate space.
+/// Represents an axis-aligned rectangle expressed using 1-based terminal coordinates.
+/// The type centralises the geometry primitives used throughout the layout system so that
+/// widgets reason about rows and columns in a consistent fashion irrespective of where
+/// they appear in the hierarchy.
 public struct BoxBounds : Equatable {
   public var row    : Int
   public var column : Int
   public var width  : Int
   public var height : Int
 
+  /// Creates a new region anchored at the provided origin. Width and height are stored as-is
+  /// which keeps bounds arithmetic extremely cheap; callers are responsible for clamping to
+  /// non-negative sizes when required.
   public init ( row: Int, column: Int, width: Int, height: Int ) {
     self.row    = row
     self.column = column
@@ -21,7 +27,10 @@ public struct BoxBounds : Equatable {
 
   public var area : Int { max(0, width * height) }
 
-  // Shrinks the bounds by the provided edge insets while ensuring we never produce negative dimensions.
+  /// Returns a new box that has been contracted by the supplied edge insets. The routine
+  /// mirrors SwiftUI's behaviour by subtracting the horizontal/vertical padding from the
+  /// width and height while ensuring negative dimensions are never emitted, which keeps
+  /// downstream layout code simple and defensive.
   public func inset ( by insets: EdgeInsets ) -> BoxBounds {
     let insetRow    = row + insets.top
     let insetColumn = column + insets.leading
@@ -31,7 +40,10 @@ public struct BoxBounds : Equatable {
     return BoxBounds(row: insetRow, column: insetColumn, width: insetWidth, height: insetHeight)
   }
 
-  // Aligns the bounds within a container rect according to the requested horizontal and vertical alignment strategies.
+  /// Positions the receiver within another box using classic alignment semantics. The
+  /// calculation derives a new origin by combining the container's edges with the desired
+  /// alignment mode. Because the size is preserved we can reuse the value when repeatedly
+  /// centering or pinning widgets without recomputing widths and heights.
   public func aligned ( horizontal: HorizontalAlignment, vertical: VerticalAlignment, inside container: BoxBounds ) -> BoxBounds {
     let originRow : Int
     let originCol : Int
@@ -52,13 +64,17 @@ public struct BoxBounds : Equatable {
   }
 }
 
-// Insets mirroring SwiftUI's EdgeInsets tailored for integer terminal coordinates.
+/// Integer variant of SwiftUI's `EdgeInsets` tailored for terminal rows and columns. Widgets
+/// use the structure to describe padding around content without needing to perform manual
+/// coordinate arithmetic themselves.
 public struct EdgeInsets : Equatable {
   public var top      : Int
   public var leading  : Int
   public var bottom   : Int
   public var trailing : Int
 
+  /// Creates a set of insets that can expand or contract bounds. Default arguments make it
+  /// cheap to specify only the edges that matter for a particular calculation.
   public init ( top: Int = 0, leading: Int = 0, bottom: Int = 0, trailing: Int = 0 ) {
     self.top      = top
     self.leading  = leading
@@ -70,12 +86,16 @@ public struct EdgeInsets : Equatable {
   public var vertical   : Int { top + bottom }
 }
 
+/// Alignment options for anchoring content horizontally within a container. The values are
+/// interpreted by `BoxBounds.aligned(horizontal:vertical:inside:)` to compute the necessary
+/// origin adjustments.
 public enum HorizontalAlignment {
   case leading
   case center
   case trailing
 }
 
+/// Alignment options for anchoring content vertically inside a container box.
 public enum VerticalAlignment {
   case top
   case center

--- a/Sources/CodexTUI/Layout/LayoutContext.swift
+++ b/Sources/CodexTUI/Layout/LayoutContext.swift
@@ -1,12 +1,17 @@
 import Foundation
 
-// Captures the contextual information widgets require to calculate geometry and styling.
+/// Bundles the information a widget requires to perform layout: its assigned bounds, the active
+/// theme palette, the focus snapshot and any auxiliary environment values derived from the
+/// surrounding scene. Passing a single value keeps the layout signatures terse while still
+/// conveying everything a widget needs to make sizing and styling decisions.
 public struct LayoutContext {
   public var bounds       : BoxBounds
   public var theme        : Theme
   public var focus        : FocusChain.Snapshot
   public var environment  : EnvironmentValues
 
+  /// Creates a context for a specific widget. The environment defaults mirror the standard
+  /// scene configuration so most widgets can opt-in to additional values only when necessary.
   public init ( bounds: BoxBounds, theme: Theme, focus: FocusChain.Snapshot, environment: EnvironmentValues = EnvironmentValues() ) {
     self.bounds      = bounds
     self.theme       = theme
@@ -15,12 +20,17 @@ public struct LayoutContext {
   }
 }
 
-// Additional environmental values surfaced to widgets during layout.
+/// Extra knobs surfaced to layout routines that describe global chrome such as menu/status bar
+/// heights and any content padding the scaffold applies. The container updates these values when
+/// composing nested contexts so children can react without recomputing their ancestors' state.
 public struct EnvironmentValues {
   public var menuBarHeight   : Int
   public var statusBarHeight : Int
   public var contentInsets   : EdgeInsets
 
+  /// Constructs a new collection of environment values. Default arguments provide sensible
+  /// platform-friendly values so callers only override the properties that are relevant to the
+  /// current subtree.
   public init ( menuBarHeight: Int = 1, statusBarHeight: Int = 1, contentInsets: EdgeInsets = EdgeInsets() ) {
     self.menuBarHeight   = menuBarHeight
     self.statusBarHeight = statusBarHeight

--- a/Sources/CodexTUI/Platform/SignalHandling.swift
+++ b/Sources/CodexTUI/Platform/SignalHandling.swift
@@ -7,7 +7,8 @@ import Glibc
 import Darwin
 #endif
 
-// Thin wrapper around DispatchSourceSignal that hides platform conditional imports.
+/// Thin wrapper around `DispatchSourceSignal` that hides platform conditional imports and exposes a
+/// simple API for listening to terminal resize notifications.
 public final class SignalObserver {
   public typealias Handler = () -> Void
 
@@ -23,12 +24,14 @@ public final class SignalObserver {
     self.handlerQueue    = handlerQueue
   }
 
+  /// Registers the closure that should run when the monitored signal fires.
   public func setHandler ( _ handler: @escaping Handler ) {
     self.handler = handler
   }
 
   
-  // Begins listening for the configured signal and forwards notifications to the handler.
+  /// Begins listening for the configured signal and forwards notifications to the handler queue when
+  /// events arrive. Subsequent calls are ignored while the observer is active.
   public func start () {
     
     guard source == nil else { return }
@@ -46,7 +49,8 @@ public final class SignalObserver {
     self.source = source
   }
 
-  // Cancels the dispatch source and releases the handler closure.
+  /// Cancels the dispatch source and releases the handler closure to avoid retain cycles. Safe to call
+  /// multiple times.
   public func stop () {
     source?.cancel()
     source = nil

--- a/Sources/CodexTUI/Platform/TerminalModeController.swift
+++ b/Sources/CodexTUI/Platform/TerminalModeController.swift
@@ -6,7 +6,8 @@ import Darwin
 import Glibc
 #endif
 
-// Captures terminal attributes and toggles the descriptor between cooked and raw modes.
+/// Captures terminal attributes and toggles the descriptor between cooked and raw modes. Exposed as
+/// an open class so platform-specific subclasses can extend the behaviour if required.
 open class TerminalModeController {
   private let descriptor       : Int32
   private var originalSettings : termios?
@@ -18,7 +19,7 @@ open class TerminalModeController {
     self.isRawModeActive  = false
   }
 
-  // Applies raw mode so key presses are delivered immediately without buffering.
+  /// Applies raw mode so key presses are delivered immediately without buffering.
   open func enterRawMode () {
     guard isRawModeActive == false else { return }
     guard var attributes = TerminalModeController.captureAttributes(of: descriptor) else { return }
@@ -30,7 +31,7 @@ open class TerminalModeController {
     }
   }
 
-  // Restores the descriptor to the previously captured cooked mode settings.
+  /// Restores the descriptor to the previously captured cooked mode settings.
   open func restore () {
     guard isRawModeActive else { return }
     guard var attributes = originalSettings else { return }

--- a/Sources/CodexTUI/Rendering/Surface.swift
+++ b/Sources/CodexTUI/Rendering/Surface.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TerminalOutput
 
-// Represents a single cell in the terminal buffer and the styling required to display it.
+/// Represents a single cell in the terminal buffer and the styling required to display it.
 public struct SurfaceTile : Equatable {
   public var character  : Character
   public var attributes : ColorPair
@@ -16,7 +16,8 @@ public extension SurfaceTile {
   static let blank : SurfaceTile = SurfaceTile(character: " ", attributes: ColorPair())
 }
 
-// Lightweight framebuffer used to track differences between frames for efficient redraws.
+/// Lightweight framebuffer used to track differences between frames for efficient redraws. Widgets
+/// render into this structure and the runtime converts the recorded mutations into ANSI sequences.
 public struct Surface {
   public private(set) var width             : Int
   public private(set) var height            : Int
@@ -61,12 +62,13 @@ public struct Surface {
     tiles[indexFor(row: row, column: column)] = tile
   }
 
-  // Snapshot the current frame so the diff can be computed after widgets finish rendering.
+  /// Snapshots the current frame so the diff can be computed after widgets finish rendering.
   public mutating func beginFrame () {
     previousFrameTiles = tiles
   }
 
-  // Produces a minimal list of changed tiles. When the surface dimensions change we fall back to a full refresh.
+  /// Produces a minimal list of changed tiles. When the surface dimensions change we fall back to a
+  /// full refresh so the terminal state remains consistent.
   public mutating func diff () -> [SurfaceChange] {
     guard needsFullRefresh == false else {
       needsFullRefresh = false
@@ -113,13 +115,14 @@ public struct Surface {
   }
 }
 
+/// Describes a single tile change emitted by the framebuffer diff.
 public struct SurfaceChange : Equatable {
   public let row    : Int
   public let column : Int
   public let tile   : SurfaceTile
 }
 
-// Converts surface mutations into terminal escape sequences.
+/// Converts surface mutations into terminal escape sequences so they can be written to the terminal.
 public enum SurfaceRenderer {
   public static func sequences ( for changes: [SurfaceChange] ) -> [AnsiSequence] {
     guard changes.isEmpty == false else { return [] }

--- a/Sources/CodexTUI/Runtime/MenuController.swift
+++ b/Sources/CodexTUI/Runtime/MenuController.swift
@@ -1,7 +1,9 @@
 import Foundation
 import TerminalInput
 
-// Coordinates menu state, overlays and keyboard routing for menu bars.
+/// Coordinates menu state, overlays and keyboard routing for menu bars. The controller owns the
+/// currently visible scaffold and swaps overlays as menus open or close so the scene always reflects
+/// the latest interaction state.
 public final class MenuController {
   public private(set) var scene              : Scene
   public private(set) var activeOverlayBounds: BoxBounds?

--- a/Sources/CodexTUI/Runtime/MessageBoxController.swift
+++ b/Sources/CodexTUI/Runtime/MessageBoxController.swift
@@ -1,7 +1,11 @@
 import Foundation
 import TerminalInput
 
+/// Manages presentation of `MessageBox` overlays including keyboard routing, focus restoration and
+/// styling overrides. Scenes interact with the controller instead of constructing overlays directly so
+/// dismissal and re-entry behaviour remain consistent.
 public final class MessageBoxController {
+  /// Snapshot of the data required to render a message box at a particular moment.
   private struct State {
     var title               : String
     var messageLines        : [String]

--- a/Sources/CodexTUI/Runtime/SelectionListController.swift
+++ b/Sources/CodexTUI/Runtime/SelectionListController.swift
@@ -1,7 +1,11 @@
 import Foundation
 import TerminalInput
 
+/// Presents `SelectionList` overlays and manages keyboard navigation, focus restoration and theme
+/// customisation. It mirrors the behaviour of `MessageBoxController` but tailored to scrolling lists
+/// of selectable entries.
 public final class SelectionListController {
+  /// Snapshot capturing the entries, selection index and style overrides for the list overlay.
   private struct State {
     var title                 : String
     var entries               : [SelectionListEntry]

--- a/Sources/CodexTUI/Runtime/TerminalDriver.swift
+++ b/Sources/CodexTUI/Runtime/TerminalDriver.swift
@@ -8,7 +8,7 @@ import Glibc
 import Darwin
 #endif
 
-// Controls how the driver initialises and interacts with the terminal.
+/// Controls how the driver initialises and interacts with the terminal.
 public struct RuntimeConfiguration {
   public var initialBounds      : BoxBounds
   /// Controls whether the driver switches to the terminal's alternate buffer.
@@ -23,8 +23,10 @@ public struct RuntimeConfiguration {
   }
 }
 
-// Orchestrates input handling, scene rendering and terminal lifecycle management.
+/// Orchestrates input handling, scene rendering and terminal lifecycle management. The driver takes
+/// ownership of the terminal while running and ensures the display is kept in sync with scene updates.
 public final class TerminalDriver {
+  /// Lifecycle states the driver can occupy.
   public enum State {
     case stopped
     case running

--- a/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
+++ b/Sources/CodexTUI/Runtime/TextEntryBoxController.swift
@@ -1,7 +1,11 @@
 import Foundation
 import TerminalInput
 
+/// Presents `TextEntryBox` overlays and handles text editing, caret positioning and button activation
+/// while preserving scene focus. The controller encapsulates the state machine required to turn raw
+/// terminal tokens into edits on the underlying text buffer.
 public final class TextEntryBoxController {
+  /// Snapshot of the text entry box configuration and runtime editing state.
   private struct State {
     var title               : String
     var prompt              : String?

--- a/Sources/CodexTUI/Scenes/Scene.swift
+++ b/Sources/CodexTUI/Scenes/Scene.swift
@@ -1,7 +1,8 @@
 import Foundation
 import TerminalOutput
 
-// Configuration that shapes how the scene should be rendered and styled.
+/// Configuration that shapes how a scene should be rendered and styled. It captures the theme, the
+/// layout environment and whether standard chrome such as the menu and status bars should be shown.
 public struct SceneConfiguration {
   public var theme        : Theme
   public var environment  : EnvironmentValues
@@ -16,7 +17,8 @@ public struct SceneConfiguration {
   }
 }
 
-// The root object describing a hierarchy of widgets and overlays that can be rendered by the driver.
+/// Root object describing a hierarchy of widgets and overlays that can be rendered by the terminal
+/// driver. The scene owns the focus chain, current configuration and the widget tree entry point.
 public final class Scene {
   public var configuration : SceneConfiguration
   public var focusChain    : FocusChain
@@ -30,17 +32,22 @@ public final class Scene {
     self.overlays      = overlays
   }
 
-  // Adds a focusable widget to the scene-wide focus traversal chain.
+  /// Registers a focusable widget with the scene-wide focus chain so it participates in keyboard
+  /// traversal.
   public func registerFocusable ( _ widget: FocusableWidget ) {
     focusChain.register(node: widget.focusNode())
   }
 
-  // Generates a LayoutContext bound to the provided viewport, capturing the current focus and theme state.
+  /// Generates a `LayoutContext` bound to the provided viewport, capturing the current focus snapshot,
+  /// theme and environment. Widgets use this context when calculating their geometry.
   public func layoutContext ( for bounds: BoxBounds ) -> LayoutContext {
     return LayoutContext(bounds: bounds, theme: configuration.theme, focus: focusChain.snapshot(), environment: configuration.environment)
   }
 
-  // Materialises the widget hierarchy into render commands and forwards the resulting surface changes as terminal sequences.
+  /// Materialises the widget hierarchy into render commands and forwards the resulting surface changes
+  /// as terminal sequences. The method clears and resizes the surface, asks the root widget and any
+  /// overlays to produce their layout results, writes the commands into the framebuffer and finally
+  /// converts the diff into ANSI sequences suitable for terminal output.
   public func render ( into surface: inout Surface, bounds: BoxBounds ) -> [AnsiSequence] {
     surface.beginFrame()
     surface.resize(
@@ -76,7 +83,9 @@ public final class Scene {
 }
 
 public extension Scene {
-  // Convenience for composing a typical scene that contains a menu bar, body content and an optional status bar.
+  /// Convenience factory that assembles a scene containing the standard scaffold layout. Callers can
+  /// supply optional menu and status bars alongside the body content and overlays while still reusing
+  /// the default focus chain and configuration values.
   static func standard ( menuBar: MenuBar? = nil, content: AnyWidget, statusBar: StatusBar? = nil, configuration: SceneConfiguration = SceneConfiguration(), focusChain: FocusChain = FocusChain(), overlays: [AnyWidget] = [] ) -> Scene {
     let scaffold    = Scaffold(menuBar: menuBar, content: content, statusBar: statusBar)
     let rootWidget  = AnyWidget(scaffold)

--- a/Sources/CodexTUI/Styling/Theme.swift
+++ b/Sources/CodexTUI/Styling/Theme.swift
@@ -1,7 +1,8 @@
 import Foundation
 import TerminalOutput
 
-// Couples optional foreground/background colours with a text style.
+/// Couples optional foreground/background colours with a text style. Widgets use the structure to
+/// describe how tiles should appear without dealing with terminal escape sequence details directly.
 public struct ColorPair : Equatable {
   public var foreground : TerminalOutput.Color?
   public var background : TerminalOutput.Color?
@@ -20,7 +21,8 @@ public func == ( lhs: ColorPair, rhs: ColorPair ) -> Bool {
   return foregroundEqual && backgroundEqual && lhs.style == rhs.style
 }
 
-// Groups a collection of related colour pairs for widgets to consume.
+/// Groups a collection of related colour pairs for widgets to consume. Themes allow applications to
+/// swap palettes without touching widget logic.
 public struct Theme : Equatable {
   public var menuBar        : ColorPair
   public var statusBar      : ColorPair

--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -2,6 +2,7 @@ import CodexTUI
 import Foundation
 import TerminalInput
 
+/// Minimal interactive application that wires together controllers to showcase CodexTUI features.
 final class DemoApplication {
   private let driver                 : TerminalDriver
   private let logBuffer              : TextBuffer


### PR DESCRIPTION
## Summary
- add explanatory documentation to core types across layout, runtime, styling, and demo modules
- describe control flow and calculations inside every layout routine to clarify rendering behaviour
- annotate controllers and supporting models so responsibilities and state transitions are explicit

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e597ed430c8328bb4516c9e1a38536