### PR TITLE
Add text IO channel infrastructure

### DIFF
--- a/Sources/CodexTUI/Components/TextBuffer.swift
+++ b/Sources/CodexTUI/Components/TextBuffer.swift
@@ -10,6 +10,13 @@ public final class TextBuffer : FocusableWidget {
   public var style           : ColorPair
   public var highlightStyle  : ColorPair
   public var isInteractive   : Bool
+  public var onNeedsDisplay  : ( () -> Void )?
+
+  public private(set) var textIOChannel : TextIOChannel?
+
+  private var lineSeparator        : String
+  private var pendingLineFragment  : String
+  private var hasPendingDisplayLine: Bool
 
   public init ( identifier: FocusIdentifier, lines: [String] = [], scrollOffset: Int = 0, style: ColorPair = ColorPair(), highlightStyle: ColorPair = ColorPair(), isInteractive: Bool = false ) {
     self.focusIdentifier = identifier
@@ -18,6 +25,11 @@ public final class TextBuffer : FocusableWidget {
     self.style           = style
     self.highlightStyle  = highlightStyle
     self.isInteractive   = isInteractive
+    self.onNeedsDisplay  = nil
+    self.textIOChannel   = nil
+    self.lineSeparator        = "\n"
+    self.pendingLineFragment  = ""
+    self.hasPendingDisplayLine = false
   }
 
   // Exposes the focus metadata the focus chain uses to manage traversal.
@@ -28,6 +40,15 @@ public final class TextBuffer : FocusableWidget {
   public func append ( line: String ) {
     lines.append(line)
     scrollOffset  = max(0, lines.count - 1)
+  }
+
+  public func attach ( channel: TextIOChannel, lineSeparator: String = "\n" ) {
+    textIOChannel?.delegate = nil
+    textIOChannel          = channel
+    self.lineSeparator        = lineSeparator.isEmpty ? "\n" : lineSeparator
+    pendingLineFragment       = ""
+    hasPendingDisplayLine     = false
+    channel.delegate          = self
   }
 
   /// Renders the text buffer into the supplied bounds. The layout routine first applies any content
@@ -66,5 +87,89 @@ public final class TextBuffer : FocusableWidget {
     }
 
     return WidgetLayoutResult(bounds: bounds, commands: commands)
+  }
+}
+
+extension TextBuffer : TextIOChannelDelegate {
+  public func textIOChannel ( _ channel: TextIOChannel, didReceive fragment: String ) {
+    guard channel === textIOChannel else { return }
+    guard fragment.isEmpty == false else { return }
+
+    applyIncoming(fragment: fragment)
+  }
+
+  private func applyIncoming ( fragment: String ) {
+    var changed = false
+    let separator = lineSeparator
+
+    if separator.isEmpty {
+      changed = updatePendingLine(with: pendingLineFragment + fragment) || changed
+    } else {
+      let buffer   = pendingLineFragment + fragment
+      let segments = buffer.components(separatedBy: separator)
+
+      guard segments.isEmpty == false else { return }
+
+      for index in 0..<(segments.count - 1) {
+        changed = finalizePendingLine(with: segments[index]) || changed
+      }
+
+      let trailing = segments.last ?? ""
+      if trailing.isEmpty {
+        changed = clearPendingLine() || changed
+      } else {
+        changed = updatePendingLine(with: trailing) || changed
+      }
+    }
+
+    if changed {
+      onNeedsDisplay?()
+    }
+  }
+
+  @discardableResult
+  private func finalizePendingLine ( with text: String ) -> Bool {
+    if hasPendingDisplayLine, lines.isEmpty == false {
+      lines[lines.count - 1] = text
+    } else {
+      lines.append(text)
+    }
+    pendingLineFragment   = ""
+    hasPendingDisplayLine = false
+    scrollOffset          = max(0, lines.count - 1)
+    return true
+  }
+
+  @discardableResult
+  private func updatePendingLine ( with text: String ) -> Bool {
+    pendingLineFragment = text
+
+    guard text.isEmpty == false else { return clearPendingLine() }
+
+    if hasPendingDisplayLine {
+      if lines.isEmpty == false {
+        lines[lines.count - 1] = text
+      } else {
+        lines.append(text)
+      }
+    } else {
+      lines.append(text)
+      hasPendingDisplayLine = true
+    }
+
+    scrollOffset = max(0, lines.count - 1)
+    return true
+  }
+
+  @discardableResult
+  private func clearPendingLine () -> Bool {
+    pendingLineFragment = ""
+    guard hasPendingDisplayLine else { return false }
+    if lines.isEmpty == false {
+      lines.removeLast()
+    }
+    hasPendingDisplayLine = false
+    scrollOffset          = max(0, lines.count - 1)
+    return true
   }
 }

--- a/Sources/CodexTUI/Platform/FileHandleTextIOChannel.swift
+++ b/Sources/CodexTUI/Platform/FileHandleTextIOChannel.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Dispatch
+
+/// Concrete `TextIOChannel` backed by a `FileHandle`. The channel listens for inbound data using a
+/// `DispatchSourceRead`, decodes UTF-8 fragments, and writes outbound data using the paired file
+/// handle so callers can bridge to serial ports or pseudo terminals.
+public final class FileHandleTextIOChannel : TextIOChannel {
+  public weak var delegate : TextIOChannelDelegate?
+
+  private let readHandle  : FileHandle
+  private let writeHandle : FileHandle
+  private let queue       : DispatchQueue
+  private var source      : DispatchSourceRead?
+  private var pendingData : Data
+
+  public init ( readHandle: FileHandle, writeHandle: FileHandle? = nil, queue: DispatchQueue = DispatchQueue(label: "CodexTUI.FileHandleTextIOChannel") ) {
+    self.readHandle  = readHandle
+    self.writeHandle = writeHandle ?? readHandle
+    self.queue       = queue
+    self.pendingData = Data()
+  }
+
+  public func start () {
+    guard source == nil else { return }
+
+    let descriptor = readHandle.fileDescriptor
+    let source     = DispatchSource.makeReadSource(fileDescriptor: descriptor, queue: queue)
+
+    source.setEventHandler { [weak self] in
+      guard let self = self else { return }
+
+      let available = Int(source.data)
+      guard available > 0 else { return }
+
+      let data = self.readHandle.readData(ofLength: available)
+      guard data.isEmpty == false else { return }
+
+      self.process(data: data)
+    }
+
+    source.setCancelHandler { [weak self] in
+      self?.source = nil
+    }
+
+    self.source = source
+    source.resume()
+  }
+
+  public func stop () {
+    source?.cancel()
+    source = nil
+  }
+
+  public func send ( _ text: String ) {
+    guard text.isEmpty == false else { return }
+    guard let data = text.data(using: .utf8) else { return }
+
+    queue.async { [weak self] in
+      guard let self = self else { return }
+      self.writeHandle.write(data)
+    }
+  }
+
+  private func process ( data: Data ) {
+    pendingData.append(data)
+
+    var buffer   = pendingData
+    var trailing = Data()
+
+    while buffer.isEmpty == false {
+      if let string = String(data: buffer, encoding: .utf8) {
+        pendingData = trailing
+        deliver(fragment: string)
+        return
+      }
+
+      trailing.insert(buffer.removeLast(), at: trailing.startIndex)
+    }
+
+    pendingData = trailing
+  }
+
+  private func deliver ( fragment: String ) {
+    guard fragment.isEmpty == false else { return }
+
+    DispatchQueue.main.async { [weak self] in
+      guard let self = self else { return }
+      self.delegate?.textIOChannel(self, didReceive: fragment)
+    }
+  }
+
+  deinit {
+    stop()
+  }
+}

--- a/Sources/CodexTUI/Runtime/TerminalDriver.swift
+++ b/Sources/CodexTUI/Runtime/TerminalDriver.swift
@@ -59,6 +59,12 @@ public final class TerminalDriver {
       menuController?.update(viewportBounds: currentBounds)
     }
   }
+  public var textIOController      : TextIOController? {
+    didSet {
+      oldValue?.onNeedsRedraw = nil
+      textIOController?.onNeedsRedraw = { [weak self] in self?.redraw() }
+    }
+  }
 
   private let input               : TerminalInput
   private let terminal            : TerminalOutput.Terminal
@@ -233,6 +239,10 @@ public final class TerminalDriver {
 
     if let controller = menuController, controller.handle(token: token) {
       redraw()
+      return
+    }
+
+    if let controller = textIOController, controller.handle(token: token) {
       return
     }
 

--- a/Sources/CodexTUI/Runtime/TextIOController.swift
+++ b/Sources/CodexTUI/Runtime/TextIOController.swift
@@ -1,0 +1,55 @@
+import Foundation
+import TerminalInput
+
+/// Routes keyboard text tokens from the currently focused buffer to its bound text channel and
+/// bridges asynchronous channel updates back into the render loop.
+public final class TextIOController {
+  public var scene         : Scene
+  public var onNeedsRedraw : ( () -> Void )?
+
+  private var buffers : [FocusIdentifier: TextBuffer]
+
+  public init ( scene: Scene, buffers: [TextBuffer] = [] ) {
+    self.scene   = scene
+    self.buffers = [:]
+    self.onNeedsRedraw = nil
+
+    for buffer in buffers {
+      register(buffer: buffer)
+    }
+  }
+
+  public func register ( buffer: TextBuffer ) {
+    guard buffer.isInteractive else { return }
+
+    buffers[buffer.focusIdentifier] = buffer
+
+    let existing = buffer.onNeedsDisplay
+    buffer.onNeedsDisplay = { [weak self, weak buffer] in
+      existing?()
+      guard let self = self, let buffer = buffer else { return }
+      guard let tracked = self.buffers[buffer.focusIdentifier], tracked === buffer else { return }
+      self.onNeedsRedraw?()
+    }
+  }
+
+  public func unregister ( identifier: FocusIdentifier ) {
+    buffers.removeValue(forKey: identifier)
+  }
+
+  public func buffer ( for identifier: FocusIdentifier ) -> TextBuffer? {
+    return buffers[identifier]
+  }
+
+  @discardableResult
+  public func handle ( token: TerminalInput.Token ) -> Bool {
+    guard case .text(let string) = token else { return false }
+    guard string.isEmpty == false else { return true }
+    guard let focus = scene.focusChain.active else { return false }
+    guard let buffer = buffers[focus] else { return false }
+    guard let channel = buffer.textIOChannel else { return false }
+
+    channel.send(string)
+    return true
+  }
+}

--- a/Sources/CodexTUI/TextIO/TextIOChannel.swift
+++ b/Sources/CodexTUI/TextIO/TextIOChannel.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Abstraction describing a bidirectional stream of UTF-8 text. Channels deliver decoded
+/// fragments to a delegate as data arrives and expose lifecycle hooks for resource
+/// management.
+public protocol TextIOChannel : AnyObject {
+  var delegate : TextIOChannelDelegate? { get set }
+
+  func start ()
+  func stop ()
+  func send ( _ text: String )
+}
+
+/// Receives decoded UTF-8 fragments from a `TextIOChannel`.
+public protocol TextIOChannelDelegate : AnyObject {
+  func textIOChannel ( _ channel: TextIOChannel, didReceive fragment: String )
+}


### PR DESCRIPTION
## Summary
- add the TextIOChannel protocol pair with a FileHandleTextIOChannel implementation and runtime controller support
- extend TextBuffer and TerminalDriver so interactive buffers can attach channels and route keyboard text
- document and demonstrate the text IO binding flow in the demo application and README

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e792118fc883289094fc481e692188