### PR TITLE
Adopt declarative widget builder and layout containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ import CodexTUI
 
 Understanding these pillars will help you diagnose layout issues, extend widgets, and integrate CodexTUI with other terminal data sources.
 
+## Declarative Layout DSL
+
+CodexTUI now ships with a Swift result builder dedicated to widgets. Containers such as `VStack`, `HStack`, `Split`, `Padding`, `Spacer`, and `OverlayStack` automatically compute child bounds and propagate `LayoutContext` so you rarely touch `BoxBounds` directly. Composable widgets declare a `body` assembled with these containers:
+
+```swift
+struct StatusPanel : ComposableWidget {
+  var theme : Theme
+
+  var body : some Widget {
+    OverlayStack {
+      Box(style: theme.windowChrome)
+      Padding(top: 1, leading: 2, bottom: 1, trailing: 2) {
+        VStack(spacing: 1) {
+          Label("CodexTUI", style: theme.contentDefault, alignment: .center)
+          Label("Declarative layout is now built-in.", style: theme.contentDefault)
+        }
+      }
+    }
+  }
+}
+```
+
+Because containers understand the available space they forward appropriately sized contexts to each child, keeping focus snapshots, themes, and environment values consistent without manual plumbing.
+
 ## Quick Start Demo
 
 The following example wires together the core CodexTUI widgets, attaches a `TextBuffer` to a `TextIOChannel`, and lets the `TextIOController` route keyboard text into the simulated channel. This mirrors the behaviour of the `CodexTUIDemo` target.

--- a/Sources/CodexTUI/Components/ComposableWidget.swift
+++ b/Sources/CodexTUI/Components/ComposableWidget.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public protocol ComposableWidget : Widget {
+  associatedtype Body : Widget
+  var body : Body { get }
+}
+
+public extension ComposableWidget {
+  func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    return body.layout(in: context)
+  }
+}

--- a/Sources/CodexTUI/Components/Widget.swift
+++ b/Sources/CodexTUI/Components/Widget.swift
@@ -49,6 +49,12 @@ public protocol Widget {
   func layout ( in context: LayoutContext ) -> WidgetLayoutResult
 }
 
+public extension Widget {
+  func eraseToAnyWidget () -> AnyWidget {
+    return AnyWidget(self)
+  }
+}
+
 /// Type eraser that allows heterogeneous widget hierarchies. It stores the layout closure of the
 /// underlying widget and forwards invocations without exposing the concrete type to callers.
 public struct AnyWidget : Widget {

--- a/Sources/CodexTUI/Layout/Containers/EnvironmentScope.swift
+++ b/Sources/CodexTUI/Layout/Containers/EnvironmentScope.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public struct EnvironmentScope : Widget {
+  public var modifier : (inout EnvironmentValues) -> Void
+  public var content  : AnyWidget
+
+  public init ( applying modifier: @escaping (inout EnvironmentValues) -> Void, @WidgetBuilder content: () -> [AnyWidget] ) {
+    self.modifier = modifier
+    self.content  = assembleWidget(from: content())
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    var childContext = context
+    modifier(&childContext.environment)
+    let layout = content.layout(in: childContext)
+    return WidgetLayoutResult(bounds: layout.bounds, commands: layout.commands, children: layout.children)
+  }
+}

--- a/Sources/CodexTUI/Layout/Containers/HStack.swift
+++ b/Sources/CodexTUI/Layout/Containers/HStack.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public struct HStack : Widget {
+  public var spacing  : Int
+  public var children : [AnyWidget]
+
+  public init ( spacing: Int = 0, @WidgetBuilder content: () -> [AnyWidget] ) {
+    self.spacing  = spacing
+    self.children = content()
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    guard context.bounds.width > 0 else {
+      return WidgetLayoutResult(bounds: context.bounds)
+    }
+
+    var cursorColumn = context.bounds.column
+    let maxColumn    = context.bounds.maxCol
+    var layouts      = [WidgetLayoutResult]()
+    layouts.reserveCapacity(children.count)
+
+    for (index, child) in children.enumerated() {
+      guard cursorColumn <= maxColumn else { break }
+
+      let remainingWidth = max(0, maxColumn - cursorColumn + 1)
+      guard remainingWidth > 0 else { break }
+
+      let childBounds = BoxBounds(
+        row    : context.bounds.row,
+        column : cursorColumn,
+        width  : remainingWidth,
+        height : context.bounds.height
+      )
+
+      var childContext = context
+      childContext.bounds = childBounds
+
+      let layout = child.layout(in: childContext)
+      layouts.append(layout)
+
+      let consumedWidth = layout.bounds.width
+      let nextColumn    = layout.bounds.maxCol + 1
+
+      if consumedWidth <= 0 {
+        cursorColumn = min(maxColumn + 1, cursorColumn + 1)
+      } else {
+        let proposed = max(cursorColumn + consumedWidth, nextColumn)
+        cursorColumn = min(maxColumn + 1, proposed)
+      }
+
+      if index < children.count - 1 {
+        cursorColumn = min(maxColumn + 1, cursorColumn + spacing)
+      }
+    }
+
+    return WidgetLayoutResult(bounds: context.bounds, children: layouts)
+  }
+}

--- a/Sources/CodexTUI/Layout/Containers/OverlayStack.swift
+++ b/Sources/CodexTUI/Layout/Containers/OverlayStack.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct OverlayStack : Widget {
+  public var children : [AnyWidget]
+
+  public init ( @WidgetBuilder _ content: () -> [AnyWidget] ) {
+    self.children = content()
+  }
+
+  public init ( children: [AnyWidget] ) {
+    self.children = children
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    var layouts = [WidgetLayoutResult]()
+    layouts.reserveCapacity(children.count)
+
+    for child in children {
+      layouts.append(child.layout(in: context))
+    }
+
+    return WidgetLayoutResult(bounds: context.bounds, children: layouts)
+  }
+}

--- a/Sources/CodexTUI/Layout/Containers/Padding.swift
+++ b/Sources/CodexTUI/Layout/Containers/Padding.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct Padding : Widget {
+  public var insets  : EdgeInsets
+  public var content : AnyWidget
+
+  public init ( _ insets: EdgeInsets = EdgeInsets(), @WidgetBuilder content: () -> [AnyWidget] ) {
+    self.insets  = insets
+    self.content = assembleWidget(from: content())
+  }
+
+  public init ( top: Int = 0, leading: Int = 0, bottom: Int = 0, trailing: Int = 0, @WidgetBuilder content: () -> [AnyWidget] ) {
+    self.insets  = EdgeInsets(top: top, leading: leading, bottom: bottom, trailing: trailing)
+    self.content = assembleWidget(from: content())
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    let insetBounds = context.bounds.inset(by: insets)
+    var childContext = context
+    childContext.bounds = insetBounds
+
+    let childLayout = content.layout(in: childContext)
+    return WidgetLayoutResult(bounds: context.bounds, children: [childLayout])
+  }
+}

--- a/Sources/CodexTUI/Layout/Containers/Spacer.swift
+++ b/Sources/CodexTUI/Layout/Containers/Spacer.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct Spacer : Widget {
+  public var minLength : Int
+
+  public init ( minLength: Int = 0 ) {
+    self.minLength = minLength
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    let height = max(minLength, context.bounds.height)
+    let bounds = BoxBounds(
+      row    : context.bounds.row,
+      column : context.bounds.column,
+      width  : context.bounds.width,
+      height : height
+    )
+
+    return WidgetLayoutResult(bounds: bounds)
+  }
+}

--- a/Sources/CodexTUI/Layout/Containers/Split.swift
+++ b/Sources/CodexTUI/Layout/Containers/Split.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+public enum SplitAxis {
+  case horizontal
+  case vertical
+}
+
+public enum SplitSizing {
+  case flexible
+  case fixed(Int)
+  case proportion(Double)
+
+  var fixedLength : Int? {
+    switch self {
+      case .fixed(let value) : return max(0, value)
+      default                 : return nil
+    }
+  }
+
+  var weight : Double {
+    switch self {
+      case .proportion(let value) : return max(0, value)
+      default                      : return 0
+    }
+  }
+
+  var isFlexible : Bool {
+    if case .flexible = self { return true }
+    return false
+  }
+}
+
+public struct Split : Widget {
+  public var axis       : SplitAxis
+  public var firstSize  : SplitSizing
+  public var secondSize : SplitSizing
+  public var first      : AnyWidget
+  public var second     : AnyWidget
+
+  public init ( axis: SplitAxis, firstSize: SplitSizing = .flexible, secondSize: SplitSizing = .flexible, @WidgetBuilder first: () -> [AnyWidget], @WidgetBuilder second: () -> [AnyWidget] ) {
+    self.axis       = axis
+    self.firstSize  = firstSize
+    self.secondSize = secondSize
+    self.first      = assembleWidget(from: first())
+    self.second     = assembleWidget(from: second())
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    let bounds = context.bounds
+    let total  = axis == .vertical ? bounds.height : bounds.width
+    guard total > 0 else { return WidgetLayoutResult(bounds: bounds) }
+
+    let lengths = resolvedLengths(total: total)
+    let firstLength  = max(0, min(total, lengths.first))
+    let secondLength = max(0, min(total - firstLength, lengths.second))
+
+    var layouts = [WidgetLayoutResult]()
+    layouts.reserveCapacity(2)
+
+    switch axis {
+      case .vertical :
+        let firstBounds = BoxBounds(row: bounds.row, column: bounds.column, width: bounds.width, height: firstLength)
+        var firstContext = context
+        firstContext.bounds = firstBounds
+        layouts.append(first.layout(in: firstContext))
+
+        let secondRow    = bounds.row + firstLength
+        let secondHeight = max(0, bounds.height - firstLength)
+        let secondBounds = BoxBounds(row: secondRow, column: bounds.column, width: bounds.width, height: min(secondHeight, secondLength))
+        var secondContext = context
+        secondContext.bounds = secondBounds
+        layouts.append(second.layout(in: secondContext))
+
+      case .horizontal :
+        let firstBounds = BoxBounds(row: bounds.row, column: bounds.column, width: firstLength, height: bounds.height)
+        var firstContext = context
+        firstContext.bounds = firstBounds
+        layouts.append(first.layout(in: firstContext))
+
+        let secondColumn = bounds.column + firstLength
+        let secondWidth  = max(0, bounds.width - firstLength)
+        let secondBounds = BoxBounds(row: bounds.row, column: secondColumn, width: min(secondWidth, secondLength), height: bounds.height)
+        var secondContext = context
+        secondContext.bounds = secondBounds
+        layouts.append(second.layout(in: secondContext))
+    }
+
+    return WidgetLayoutResult(bounds: bounds, children: layouts)
+  }
+
+  private func resolvedLengths ( total: Int ) -> (first: Int, second: Int) {
+    var remaining = max(0, total)
+    var first     = 0
+    var second    = 0
+
+    if let fixed = firstSize.fixedLength {
+      let clamped = min(fixed, remaining)
+      first     += clamped
+      remaining -= clamped
+    }
+
+    if let fixed = secondSize.fixedLength {
+      let clamped = min(fixed, remaining)
+      second    += clamped
+      remaining -= clamped
+    }
+
+    let firstWeight  = firstSize.weight
+    let secondWeight = secondSize.weight
+    let weightTotal  = firstWeight + secondWeight
+
+    if weightTotal > 0 && remaining > 0 {
+      let firstShare  = Int(Double(remaining) * (firstWeight / weightTotal))
+      let secondShare = Int(Double(remaining) * (secondWeight / weightTotal))
+      first     += firstShare
+      second    += secondShare
+      remaining -= (firstShare + secondShare)
+    }
+
+    if remaining > 0 {
+      let flexibleCount = (firstSize.isFlexible ? 1 : 0) + (secondSize.isFlexible ? 1 : 0)
+
+      if flexibleCount > 0 {
+        let base   = remaining / flexibleCount
+        let extra  = remaining % flexibleCount
+        var extras = extra
+
+        if firstSize.isFlexible {
+          let addition = base + (extras > 0 ? 1 : 0)
+          first     += addition
+          remaining -= addition
+          if extras > 0 { extras -= 1 }
+        }
+
+        if secondSize.isFlexible && remaining > 0 {
+          let addition = base + (extras > 0 ? 1 : 0)
+          second    += addition
+          remaining -= addition
+        }
+      }
+    }
+
+    if remaining > 0 {
+      second += remaining
+    }
+
+    return (first, second)
+  }
+}

--- a/Sources/CodexTUI/Layout/Containers/VStack.swift
+++ b/Sources/CodexTUI/Layout/Containers/VStack.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public struct VStack : Widget {
+  public var spacing  : Int
+  public var children : [AnyWidget]
+
+  public init ( spacing: Int = 0, @WidgetBuilder content: () -> [AnyWidget] ) {
+    self.spacing  = spacing
+    self.children = content()
+  }
+
+  public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    guard context.bounds.height > 0 else {
+      return WidgetLayoutResult(bounds: context.bounds)
+    }
+
+    var cursorRow = context.bounds.row
+    let maxRow    = context.bounds.maxRow
+    var layouts   = [WidgetLayoutResult]()
+    layouts.reserveCapacity(children.count)
+
+    for (index, child) in children.enumerated() {
+      guard cursorRow <= maxRow else { break }
+
+      let remainingHeight = max(0, maxRow - cursorRow + 1)
+      guard remainingHeight > 0 else { break }
+
+      let childBounds = BoxBounds(
+        row    : cursorRow,
+        column : context.bounds.column,
+        width  : context.bounds.width,
+        height : remainingHeight
+      )
+
+      var childContext = context
+      childContext.bounds = childBounds
+
+      let layout = child.layout(in: childContext)
+      layouts.append(layout)
+
+      let consumedHeight = layout.bounds.height
+      let nextRow        = layout.bounds.maxRow + 1
+
+      if consumedHeight <= 0 {
+        cursorRow = min(maxRow + 1, cursorRow + 1)
+      } else {
+        let proposed = max(cursorRow + consumedHeight, nextRow)
+        cursorRow    = min(maxRow + 1, proposed)
+      }
+
+      if index < children.count - 1 {
+        cursorRow = min(maxRow + 1, cursorRow + spacing)
+      }
+    }
+
+    return WidgetLayoutResult(bounds: context.bounds, children: layouts)
+  }
+}

--- a/Sources/CodexTUI/Layout/WidgetBuilder.swift
+++ b/Sources/CodexTUI/Layout/WidgetBuilder.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+@resultBuilder
+public enum WidgetBuilder {
+  public static func buildBlock ( _ components: [AnyWidget]... ) -> [AnyWidget] {
+    var flattened = [AnyWidget]()
+    flattened.reserveCapacity(components.reduce(0) { $0 + $1.count })
+
+    for component in components {
+      flattened.append(contentsOf: component)
+    }
+
+    return flattened
+  }
+
+  public static func buildExpression <Wrapped: Widget> ( _ expression: Wrapped ) -> [AnyWidget] {
+    return [AnyWidget(expression)]
+  }
+
+  public static func buildExpression ( _ expression: AnyWidget ) -> [AnyWidget] {
+    return [expression]
+  }
+
+  public static func buildExpression ( _ expression: [AnyWidget] ) -> [AnyWidget] {
+    return expression
+  }
+
+  public static func buildOptional ( _ component: [AnyWidget]? ) -> [AnyWidget] {
+    return component ?? []
+  }
+
+  public static func buildEither ( first component: [AnyWidget] ) -> [AnyWidget] {
+    return component
+  }
+
+  public static func buildEither ( second component: [AnyWidget] ) -> [AnyWidget] {
+    return component
+  }
+
+  public static func buildArray ( _ components: [[AnyWidget]] ) -> [AnyWidget] {
+    var flattened = [AnyWidget]()
+    flattened.reserveCapacity(components.reduce(0) { $0 + $1.count })
+
+    for component in components {
+      flattened.append(contentsOf: component)
+    }
+
+    return flattened
+  }
+
+  public static func buildLimitedAvailability ( _ component: [AnyWidget] ) -> [AnyWidget] {
+    return component
+  }
+
+  public static func buildFinalResult ( _ component: [AnyWidget] ) -> [AnyWidget] {
+    return component
+  }
+}
+
+public func assembleWidget ( from children: [AnyWidget] ) -> AnyWidget {
+  guard children.count > 1 else { return children.first ?? AnyWidget(EmptyWidget()) }
+  return AnyWidget(OverlayStack(children: children))
+}
+
+private struct EmptyWidget : Widget {
+  func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
+    return WidgetLayoutResult(bounds: context.bounds)
+  }
+}


### PR DESCRIPTION
## Summary
- add a @WidgetBuilder result builder plus reusable layout containers (VStack, HStack, Split, Padding, Spacer, OverlayStack, EnvironmentScope)
- introduce a ComposableWidget protocol and refactor core widgets and the demo workspace to use the declarative DSL
- update Box, Panel, Text (Label), Scaffold, docs, and tests to showcase the new API and verify focus/environment propagation

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ed1e2470d08328a5ee9a167bde4555