### PR TITLE
Ensure log buffer registered with TextIOController

### DIFF
--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -97,7 +97,7 @@ final class DemoApplication {
 
     textChannel            = FileHandleTextIOChannel(readHandle: channelPipe.fileHandleForReading, writeHandle: channelPipe.fileHandleForWriting)
     driver                 = CodexTUI.makeDriver(scene: scene)
-    textIOController       = TextIOController(scene: scene, buffers: [])
+    textIOController       = TextIOController(scene: scene, buffers: [logBuffer])
     messageBoxController   = MessageBoxController(scene: scene, viewportBounds: viewportBounds)
     selectionListController = SelectionListController(scene: scene, viewportBounds: viewportBounds)
     textEntryBoxController = TextEntryBoxController(scene: scene, viewportBounds: viewportBounds, startWidth: 28)
@@ -107,7 +107,6 @@ final class DemoApplication {
     focusChain.register(node: logBuffer.focusNode())
     scene.registerFocusable(logBuffer)
     logBuffer.attach(channel: textChannel)
-    textIOController.register(buffer: logBuffer)
 
     menuBar = makeMenuBar()
     menuController.menuBar = menuBar


### PR DESCRIPTION
## Summary
- initialize the TextIOController with the log buffer so it is registered once
- remove the redundant manual buffer registration in `DemoApplication.init`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed57d39f34832893fba210f7b1fc8a