### PR TITLE
Remove spacer that obscured demo log output

### DIFF
--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -28,7 +28,6 @@ private struct DemoWorkspace : ComposableWidget {
               VStack(spacing: 1) {
                 Label("Live Text IO", style: highlightedHeaderStyle(), alignment: .center)
                 Label("Typed keys echo here via the TextIOController.", style: theme.contentDefault)
-                Spacer(minLength: 1)
                 logBuffer
               }
             }


### PR DESCRIPTION
## Summary
- rely on the VStack spacing in the demo log panel so the buffer renders

## Testing
- swift build --product CodexTUIDemo
- swift run CodexTUIDemo

------
https://chatgpt.com/codex/tasks/task_e_68ed636fbc3c832885fac4bf593f80e8