### PR TITLE
Introduce StatusBar result builder API

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ final class DemoApplication {
         }
       }
     )
-    builder.statusBar    = StatusBar(items: [StatusItem(text: "ESC Exit", alignment: .leading)], style: theme.statusBar)
+    builder.statusBar    = StatusBar {
+      StatusItem(text: "ESC Exit", alignment: .leading)
+    }
     builder.menuBar      = MenuBar(items: [], style: theme.menuBar, highlightStyle: theme.highlight, dimHighlightStyle: theme.dimHighlight)
     builder.addTextBuffer(logBuffer)
     builder.initialFocus = logBuffer.focusIdentifier

--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -84,7 +84,7 @@ final class DemoApplication {
     let builder       = CodexApp.Builder(configuration: configuration, runtimeConfiguration: RuntimeConfiguration())
 
     builder.setContent(DemoWorkspace(theme: theme, logBuffer: logBuffer))
-    builder.statusBar      = DemoApplication.makeStatusBar(theme: theme)
+    builder.statusBar      = DemoApplication.makeStatusBar()
     builder.menuBar        = DemoApplication.makePlaceholderMenuBar(theme: theme)
     builder.addTextBuffer(logBuffer)
     builder.initialFocus = logBuffer.focusIdentifier
@@ -160,13 +160,12 @@ final class DemoApplication {
     return MenuBar(items: items, style: theme.menuBar, highlightStyle: theme.highlight, dimHighlightStyle: theme.dimHighlight)
   }
 
-  private static func makeStatusBar ( theme: Theme ) -> StatusBar {
-    let items = [
-      StatusItem(text: "ESC Exit", alignment: .leading),
-      StatusItem(text: "⌥D Demo Menu", alignment: .leading),
+  private static func makeStatusBar () -> StatusBar {
+    return StatusBar {
+      StatusItem(text: "ESC Exit", alignment: .leading)
+      StatusItem(text: "⌥D Demo Menu", alignment: .leading)
       StatusItem(text: "CodexTUIDemo", alignment: .trailing)
-    ]
-    return StatusBar(items: items, style: theme.statusBar)
+    }
   }
 
   private static func makePlaceholderMenuBar ( theme: Theme ) -> MenuBar {


### PR DESCRIPTION
## Summary
- add a StatusItemBuilder result builder and closure-based initializer for StatusBar while deferring to the theme by default
- update the demo application and README examples to use the new builder-driven StatusBar API

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ed7183ea248328a296376f29cc2564