### PR TITLE
Add menu builders and theme-aware defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ final class DemoApplication {
     builder.statusBar    = StatusBar {
       StatusItem(text: "ESC Exit", alignment: .leading)
     }
-    builder.menuBar      = MenuBar(items: [], style: theme.menuBar, highlightStyle: theme.highlight, dimHighlightStyle: theme.dimHighlight)
+    builder.menuBar      = MenuBar { }
     builder.addTextBuffer(logBuffer)
     builder.initialFocus = logBuffer.focusIdentifier
 

--- a/Sources/CodexTUI/Components/DropDownMenu.swift
+++ b/Sources/CodexTUI/Components/DropDownMenu.swift
@@ -6,16 +6,32 @@ import Foundation
 public struct DropDownMenu : Widget {
   public var entries        : [MenuItem.Entry]
   public var selectionIndex : Int
-  public var style          : ColorPair
-  public var highlightStyle : ColorPair
-  public var borderStyle    : ColorPair
+  public var styleOverride          : ColorPair?
+  public var highlightStyleOverride : ColorPair?
+  public var borderStyleOverride    : ColorPair?
 
   public init ( entries: [MenuItem.Entry], selectionIndex: Int = 0, style: ColorPair, highlightStyle: ColorPair, borderStyle: ColorPair ) {
     self.entries        = entries
     self.selectionIndex = selectionIndex
-    self.style          = style
-    self.highlightStyle = highlightStyle
-    self.borderStyle    = borderStyle
+    self.styleOverride          = style
+    self.highlightStyleOverride = highlightStyle
+    self.borderStyleOverride    = borderStyle
+  }
+
+  public init ( entries: [MenuItem.Entry], selectionIndex: Int = 0, style: ColorPair? = nil, highlightStyle: ColorPair? = nil, borderStyle: ColorPair? = nil ) {
+    self.entries                 = entries
+    self.selectionIndex          = selectionIndex
+    self.styleOverride           = style
+    self.highlightStyleOverride  = highlightStyle
+    self.borderStyleOverride     = borderStyle
+  }
+
+  public init ( selectionIndex: Int = 0, style: ColorPair? = nil, highlightStyle: ColorPair? = nil, borderStyle: ColorPair? = nil, @MenuEntryBuilder entries: () -> [MenuItem.Entry] ) {
+    self.entries                 = entries()
+    self.selectionIndex          = selectionIndex
+    self.styleOverride           = style
+    self.highlightStyleOverride  = highlightStyle
+    self.borderStyleOverride     = borderStyle
   }
 
   /// Delegates to `SelectionListSurface.layout` after converting the menu entries into the common
@@ -24,12 +40,15 @@ public struct DropDownMenu : Widget {
   /// border logic without duplicating calculations.
   public func layout ( in context: LayoutContext ) -> WidgetLayoutResult {
     let listEntries = entries.map { SelectionListEntry(menuEntry: $0) }
+    let style        = styleOverride ?? context.theme.contentDefault
+    let highlight    = highlightStyleOverride ?? context.theme.highlight
+    let border       = borderStyleOverride ?? context.theme.windowChrome
     let surface     = SelectionListSurface.layout(
       entries        : listEntries,
       selectionIndex : selectionIndex,
       style          : style,
-      highlightStyle : highlightStyle,
-      borderStyle    : borderStyle,
+      highlightStyle : highlight,
+      borderStyle    : border,
       in             : context
     )
 

--- a/Sources/CodexTUI/Runtime/MenuController.swift
+++ b/Sources/CodexTUI/Runtime/MenuController.swift
@@ -201,13 +201,9 @@ public final class MenuController {
     let dropDownBounds = DropDownMenu.anchoredBounds(for: entries, anchoredTo: itemBounds, in: viewportBounds)
     activeOverlayBounds = dropDownBounds
 
-    let dropDown = DropDownMenu(
-      entries        : entries,
-      selectionIndex : activeEntryIndex ?? 0,
-      style          : scene.configuration.theme.contentDefault,
-      highlightStyle : scene.configuration.theme.highlight,
-      borderStyle    : scene.configuration.theme.windowChrome
-    )
+    let dropDown = DropDownMenu(selectionIndex: activeEntryIndex ?? 0) {
+      entries
+    }
 
     let overlay = Overlay(
       bounds  : dropDownBounds,

--- a/Sources/CodexTUIDemo/main.swift
+++ b/Sources/CodexTUIDemo/main.swift
@@ -85,7 +85,7 @@ final class DemoApplication {
 
     builder.setContent(DemoWorkspace(theme: theme, logBuffer: logBuffer))
     builder.statusBar      = DemoApplication.makeStatusBar()
-    builder.menuBar        = DemoApplication.makePlaceholderMenuBar(theme: theme)
+    builder.menuBar        = DemoApplication.makePlaceholderMenuBar()
     builder.addTextBuffer(logBuffer)
     builder.initialFocus = logBuffer.focusIdentifier
 
@@ -110,54 +110,25 @@ final class DemoApplication {
   }
 
   private func makeMenuBar () -> MenuBar {
-    var items = [MenuItem]()
+    return MenuBar {
+      MenuItem(title: "Demo", activationKey: .meta(.alt("d"))) {
+        MenuItem.Entry(title: "Show Welcome", acceleratorHint: "↩", action: { [weak self] in self?.presentWelcomeMessage() })
+        MenuItem.Entry(title: "Command Palette…", acceleratorHint: "⌥P", action: { [weak self] in self?.presentCommandPalette() })
+        MenuItem.Entry(title: "Compose Message…", acceleratorHint: "⌥M", action: { [weak self] in self?.promptForCustomMessage() })
+        MenuItem.Entry(title: "Quit Demo", acceleratorHint: "ESC", action: { [weak self] in self?.shutdown() })
+      }
 
-    items.append(
-      MenuItem(
-        title         : "Demo",
-        activationKey : .meta(.alt("d")),
-        alignment     : .leading,
-        isHighlighted : false,
-        isOpen        : false,
-        entries       : [
-          MenuItem.Entry(title: "Show Welcome", acceleratorHint: "↩", action: { [weak self] in self?.presentWelcomeMessage() }),
-          MenuItem.Entry(title: "Command Palette…", acceleratorHint: "⌥P", action: { [weak self] in self?.presentCommandPalette() }),
-          MenuItem.Entry(title: "Compose Message…", acceleratorHint: "⌥M", action: { [weak self] in self?.promptForCustomMessage() }),
-          MenuItem.Entry(title: "Quit Demo", acceleratorHint: "ESC", action: { [weak self] in self?.shutdown() })
-        ]
-      )
-    )
+      MenuItem(title: "Overlays", activationKey: .meta(.alt("o"))) {
+        MenuItem.Entry(title: "Message Box", acceleratorHint: "↩", action: { [weak self] in self?.presentWelcomeMessage() })
+        MenuItem.Entry(title: "Selection List", acceleratorHint: "⌥L", action: { [weak self] in self?.presentCommandPalette() })
+        MenuItem.Entry(title: "Text Entry", acceleratorHint: "⌥T", action: { [weak self] in self?.promptForCustomMessage() })
+      }
 
-    items.append(
-      MenuItem(
-        title         : "Overlays",
-        activationKey : .meta(.alt("o")),
-        alignment     : .leading,
-        isHighlighted : false,
-        isOpen        : false,
-        entries       : [
-          MenuItem.Entry(title: "Message Box", acceleratorHint: "↩", action: { [weak self] in self?.presentWelcomeMessage() }),
-          MenuItem.Entry(title: "Selection List", acceleratorHint: "⌥L", action: { [weak self] in self?.presentCommandPalette() }),
-          MenuItem.Entry(title: "Text Entry", acceleratorHint: "⌥T", action: { [weak self] in self?.promptForCustomMessage() })
-        ]
-      )
-    )
-
-    items.append(
-      MenuItem(
-        title         : "Help",
-        activationKey : .meta(.alt("h")),
-        alignment     : .trailing,
-        isHighlighted : false,
-        isOpen        : false,
-        entries       : [
-          MenuItem.Entry(title: "About CodexTUI", acceleratorHint: "↩", action: { [weak self] in self?.presentAboutDialog() }),
-          MenuItem.Entry(title: "View Tips", acceleratorHint: "⌥I", action: { [weak self] in self?.presentTipsMessage() })
-        ]
-      )
-    )
-
-    return MenuBar(items: items, style: theme.menuBar, highlightStyle: theme.highlight, dimHighlightStyle: theme.dimHighlight)
+      MenuItem(title: "Help", activationKey: .meta(.alt("h")), alignment: .trailing) {
+        MenuItem.Entry(title: "About CodexTUI", acceleratorHint: "↩", action: { [weak self] in self?.presentAboutDialog() })
+        MenuItem.Entry(title: "View Tips", acceleratorHint: "⌥I", action: { [weak self] in self?.presentTipsMessage() })
+      }
+    }
   }
 
   private static func makeStatusBar () -> StatusBar {
@@ -168,8 +139,8 @@ final class DemoApplication {
     }
   }
 
-  private static func makePlaceholderMenuBar ( theme: Theme ) -> MenuBar {
-    return MenuBar(items: [], style: theme.menuBar, highlightStyle: theme.highlight, dimHighlightStyle: theme.dimHighlight)
+  private static func makePlaceholderMenuBar () -> MenuBar {
+    return MenuBar { }
   }
 
   private static func defaultBackgroundMessages () -> [String] {

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -788,21 +788,11 @@ final class CodexTUITests: XCTestCase {
       MenuItem.Entry(title: "First", acceleratorHint: "Ctrl+F"),
       MenuItem.Entry(title: "Second", acceleratorHint: "Ctrl+S")
     ]
-    let menuItems  = [
-      MenuItem(
-        title         : "File",
-        activationKey : .meta(.alt("f")),
-        alignment     : .leading,
-        isHighlighted : true,
-        entries       : entries
-      )
-    ]
-    let menuBar    = MenuBar(
-      items : menuItems,
-      style : theme.menuBar,
-      highlightStyle   : theme.highlight,
-      dimHighlightStyle: theme.dimHighlight
-    )
+    let menuBar    = MenuBar {
+      MenuItem(title: "File", activationKey: .meta(.alt("f")), isHighlighted: true) {
+        entries
+      }
+    }
     let buffer     = TextBuffer(identifier: FocusIdentifier("log"), isInteractive: true)
     let content    = AnyWidget(buffer)
     let focusChain = FocusChain()
@@ -834,16 +824,11 @@ final class CodexTUITests: XCTestCase {
       MenuItem.Entry(title: "First"),
       MenuItem.Entry(title: "Second")
     ]
-    let menuItems  = [
-      MenuItem(
-        title         : "File",
-        activationKey : .meta(.alt("f")),
-        alignment     : .leading,
-        isHighlighted : true,
-        entries       : entries
-      )
-    ]
-    let menuBar    = MenuBar(items: menuItems, style: theme.menuBar, highlightStyle: theme.highlight, dimHighlightStyle: theme.dimHighlight)
+    let menuBar    = MenuBar {
+      MenuItem(title: "File", activationKey: .meta(.alt("f")), isHighlighted: true) {
+        entries
+      }
+    }
     let buffer     = TextBuffer(identifier: FocusIdentifier("log"), isInteractive: true)
     let content    = AnyWidget(buffer)
     let focusChain = FocusChain()
@@ -870,16 +855,11 @@ final class CodexTUITests: XCTestCase {
   func testMenuControllerEscapeRestoresFocusAndClearsOverlay () {
     let theme      = Theme.codex
     let entries    = [MenuItem.Entry(title: "Only Item")]
-    let menuItems  = [
-      MenuItem(
-        title         : "File",
-        activationKey : .meta(.alt("f")),
-        alignment     : .leading,
-        isHighlighted : true,
-        entries       : entries
-      )
-    ]
-    let menuBar    = MenuBar(items: menuItems, style: theme.menuBar, highlightStyle: theme.highlight, dimHighlightStyle: theme.dimHighlight)
+    let menuBar    = MenuBar {
+      MenuItem(title: "File", activationKey: .meta(.alt("f")), isHighlighted: true) {
+        entries
+      }
+    }
     let buffer     = TextBuffer(identifier: FocusIdentifier("log"), isInteractive: true)
     let content    = AnyWidget(buffer)
     let focusChain = FocusChain()


### PR DESCRIPTION
## Summary
- add `MenuItemBuilder`/`MenuEntryBuilder` result builders and convenience initialisers so `MenuBar` and `MenuItem` resolve styles from the layout theme
- update `DropDownMenu` to accept builder-based entry definitions while deferring style resolution to `LayoutContext`
- migrate the menu controller, demo, README, and tests to the builder APIs to remove duplicated theme plumbing

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ed74e0ff748328a879c9a36faced52