### PR TITLE
Adopt builder-based SelectionList initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,16 @@ CodexTUI's runtime controllers encapsulate the behaviour behind menus, modal ove
 - [`MenuController`](Sources/CodexTUI/Runtime/MenuController.swift) orchestrates menu bar focus, overlay creation, and keyboard routing while remembering the previously focused widget.【F:Sources/CodexTUI/Runtime/MenuController.swift†L4-L140】
 - [`MessageBoxController`](Sources/CodexTUI/Runtime/MessageBoxController.swift) presents `MessageBox` overlays, tracks the highlighted button, and restores focus and overlays after dismissal.【F:Sources/CodexTUI/Runtime/MessageBoxController.swift†L4-L199】
 - [`SelectionListController`](Sources/CodexTUI/Runtime/SelectionListController.swift) renders scrollable `SelectionList` overlays, handles arrow-key navigation, and keeps the user's place when the viewport changes.【F:Sources/CodexTUI/Runtime/SelectionListController.swift†L4-L188】
+-   The controller now constructs lists with the builder-style initializer so overlays inherit the active theme automatically:
+
+    ```swift
+    SelectionList(title: "Recent Files") {
+      SelectionListEntry(title: "Report.md", acceleratorHint: "⌘O")
+      SelectionListEntry(title: "Specs.txt")
+    }
+    ```
+
+    Pass explicit overrides only when the overlay needs a custom palette.
 - [`TextEntryBoxController`](Sources/CodexTUI/Runtime/TextEntryBoxController.swift) powers modal text prompts by managing caret edits, button activation, and live redraw requests.【F:Sources/CodexTUI/Runtime/TextEntryBoxController.swift†L4-L244】
 - [`TextIOController`](Sources/CodexTUI/Runtime/TextIOController.swift) delivers keyboard `.text` tokens to the focused interactive buffer and schedules redraws whenever a registered buffer reports new output.【F:Sources/CodexTUI/Runtime/TextIOController.swift†L4-L53】
 

--- a/Sources/CodexTUI/Runtime/SelectionListController.swift
+++ b/Sources/CodexTUI/Runtime/SelectionListController.swift
@@ -142,30 +142,18 @@ public final class SelectionListController {
     let maxIndex      = max(0, state.entries.count - 1)
     state.selectionIndex = max(0, min(state.selectionIndex, maxIndex))
 
-    let bounds         = SelectionList.centeredBounds(title: state.title, entries: state.entries, in: viewportBounds)
-    let theme          = scene.configuration.theme
-    let contentStyle   = state.contentStyleOverride ?? theme.contentDefault
-    let highlightStyle = state.highlightStyleOverride ?? theme.highlight
-    let borderStyle    = state.borderStyleOverride ?? theme.windowChrome
-    let titleStyle     : ColorPair
-
-    if let override = state.titleStyleOverride {
-      titleStyle = override
-    } else {
-      var defaultTitle = theme.contentDefault
-      defaultTitle.style.insert(.bold)
-      titleStyle = defaultTitle
-    }
+    let bounds = SelectionList.centeredBounds(title: state.title, entries: state.entries, in: viewportBounds)
 
     let widget = SelectionList(
-      title          : state.title,
-      entries        : state.entries,
-      selectionIndex : state.selectionIndex,
-      titleStyle     : titleStyle,
-      style          : contentStyle,
-      highlightStyle : highlightStyle,
-      borderStyle    : borderStyle
-    )
+      title                  : state.title,
+      selectionIndex         : state.selectionIndex,
+      titleStyleOverride     : state.titleStyleOverride,
+      contentStyleOverride   : state.contentStyleOverride,
+      highlightStyleOverride : state.highlightStyleOverride,
+      borderStyleOverride    : state.borderStyleOverride
+    ) {
+      state.entries
+    }
 
     let overlay = Overlay(
       bounds  : bounds,

--- a/Tests/CodexTUITests/CodexTUITests.swift
+++ b/Tests/CodexTUITests/CodexTUITests.swift
@@ -926,13 +926,10 @@ final class CodexTUITests: XCTestCase {
     let context     = LayoutContext(bounds: bounds, theme: theme, focus: focus)
     let selection   = SelectionList(
       title          : title,
-      entries        : entries,
-      selectionIndex : 1,
-      titleStyle     : theme.highlight,
-      style          : theme.contentDefault,
-      highlightStyle : theme.highlight,
-      borderStyle    : theme.windowChrome
-    )
+      selectionIndex : 1
+    ) {
+      entries
+    }
     let layout      = selection.layout(in: context)
     let commands    = layout.flattenedCommands()
     let interior    = bounds.inset(by: EdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1))
@@ -943,7 +940,9 @@ final class CodexTUITests: XCTestCase {
 
     let titleCommand = commands.last { $0.row == titleRow && $0.column == startColumn }
     XCTAssertEqual(titleCommand?.tile.character, usableTitle.first)
-    XCTAssertEqual(titleCommand?.tile.attributes, theme.highlight)
+    var expectedTitleStyle = theme.contentDefault
+    expectedTitleStyle.style.insert(.bold)
+    XCTAssertEqual(titleCommand?.tile.attributes, expectedTitleStyle)
 
     let entryStartRow   = interior.row + 1
     let firstRowCommand = commands.last { $0.row == entryStartRow && $0.column == interior.column }


### PR DESCRIPTION
## Summary
- add a SelectionListEntryBuilder and convenience initializer that resolves styles from the active theme when overrides are absent
- migrate SelectionListController and unit tests to the closure-based initializer
- document the builder pattern for constructing selection lists

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68ed786d49a48328817acef55e10251e